### PR TITLE
Parallel data representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ See file LICENSE.txt
 [9] Kudo, T. & Matsumoto, Y. (2002). Japanese Dependency Analysis using Cascaded Chunking, In CoNLL 2002. pp.63-69.
 
 # Changelog
+
+* 2025-09-11 v2.16
+  * add parallel corpus information to machine-readable metadata
+  * add parallel data support with parallel_id metadata
 * 2020-05-   v2.6
   * Update for v2.6.  Introduce the conversion method of UD-Japanese BCCWJ [3]
   
@@ -198,7 +202,7 @@ See https://github.com/ryanmcd/uni-dep-tb for more details
 Data available since: UD v1.4
 License: CC BY-SA 4.0
 Includes text: yes
-Parallel: no
+Parallel: jagsd
 Genre: news blog
 Lemmas: converted from manual
 UPOS: converted from manual

--- a/ja_gsd-ud-dev.conllu
+++ b/ja_gsd-ud-dev.conllu
@@ -1,5 +1,6 @@
 # newdoc id = dev-s1
 # sent_id = dev-s1
+# parallel_id = jagsd/dev1
 # text = ただし、50周年ソングに変更後は、EDも歌つきのものが使われた。
 1	ただし	但し	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -25,6 +26,7 @@
 
 # newdoc id = dev-s2
 # sent_id = dev-s2
+# parallel_id = jagsd/dev2
 # text = 私は初めてだったんだけど思っていたよりも魚は新鮮でした。
 1	私	私	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -49,6 +51,7 @@
 
 # newdoc id = dev-s4
 # sent_id = dev-s4
+# parallel_id = jagsd/dev4
 # text = セントラル・リーグ審判員の水落朋大は実兄。
 1	セントラル	セントラル	NOUN	名詞-普通名詞-一般	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セントラル,セントラル,セントラル,セントラル,セントラル,,,セントラル,セントラルリーグシンパンイン,セントラル・リーグ審判員
 2	・	・	SYM	補助記号-一般	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,セントラルリーグシンパンイン,セントラル・リーグ審判員
@@ -64,6 +67,7 @@
 
 # newdoc id = dev-s5
 # sent_id = dev-s5
+# parallel_id = jagsd/dev5
 # text = 多彩なライブアクトとともに、祝日前の渋谷の夜を盛り上げてくれそうだ。
 1	多彩	多彩	ADJ	形状詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=タサイ,多彩,多彩,多彩,タサイ,,,タサイ,タサイ,多彩
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -89,6 +93,7 @@
 
 # newdoc id = dev-s6
 # sent_id = dev-s6
+# parallel_id = jagsd/dev6
 # text = 今作品では大会でのパラメータUPが非常に大きく、ALL999への育成は回復アイテムを投与しつつ、冬眠、復活を繰り返し大会に連続して出すという方法が取られた。
 1	今	今	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コン,今,今,今,コン,,,コン,コンサクヒン,今作品
 2	作品	作品	NOUN	名詞-普通名詞-一般	_	13	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サクヒン,作品,作品,作品,サクヒン,,,サクヒン,コンサクヒン,今作品
@@ -139,6 +144,7 @@
 
 # newdoc id = dev-s7
 # sent_id = dev-s7
+# parallel_id = jagsd/dev7
 # text = ゲーム入力のレスポンスをよくするためには、これを1秒間に通常30回以上行う必要があり、実際に得られたデータの回数と値はゲームコントローラ内の抵抗や回路上のノイズやCPUスピード、ゲームコントローラ全体の容量からくるRC回路・時定数に依存する。
 1	ゲーム	ゲーム	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲーム,ゲーム,ゲーム,ゲーム,ゲーム,,,ゲーム,ゲームニュウリョク,ゲーム入力
 2	入力	入力	NOUN	名詞-普通名詞-サ変可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニュウリョク,入力,入力,入力,ニューリョク,,,ニュウリョク,ゲームニュウリョク,ゲーム入力
@@ -209,6 +215,7 @@
 
 # newdoc id = dev-s8
 # sent_id = dev-s8
+# parallel_id = jagsd/dev8
 # text = 姉と同じ先生だったので、話やすかったです。
 1	姉	姉	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アネ,姉,姉,姉,アネ,,,アネ,アネ,姉
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -227,6 +234,7 @@
 
 # newdoc id = dev-s9
 # sent_id = dev-s9
+# parallel_id = jagsd/dev9
 # text = 同僚教師のすみれと彩はそんな夕子と意気投合し、問題を解決するため行動を共にする。
 1	同僚	同僚	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウリョウ,同僚,同僚,同僚,ドーリョー,,,ドウリョウ,ドウリョウキョウシ,同僚教師
 2	教師	教師	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウシ,教師,教師,教師,キョーシ,,,キョウシ,ドウリョウキョウシ,同僚教師
@@ -256,6 +264,7 @@
 
 # newdoc id = dev-s10
 # sent_id = dev-s10
+# parallel_id = jagsd/dev10
 # text = ほかの複数の信者も女性宅近くで付きまとい行為をしていたとみられ,統一教会の組織的な関与の有無を慎重に調べている。
 1	ほか	他	NOUN	名詞-普通名詞-副詞可能	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -297,6 +306,7 @@
 
 # newdoc id = dev-s11
 # sent_id = dev-s11
+# parallel_id = jagsd/dev11
 # text = 背中に背負ったブースターを使って空中飛行を行う。
 1	背中	背中	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セナカ,背中,背中,背中,セナカ,,,セナカ,セナカ,背中
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -314,6 +324,7 @@
 
 # newdoc id = dev-s12
 # sent_id = dev-s12
+# parallel_id = jagsd/dev12
 # text = また、最新版のウェブブラウザを利用していても、OSやコンポーネント側にセキュリティホールが存在すれば、そこを突かれる可能性がある。
 1	また	又	CCONJ	接続詞	_	35	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -354,6 +365,7 @@
 
 # newdoc id = dev-s13
 # sent_id = dev-s13
+# parallel_id = jagsd/dev13
 # text = しかも、熱々の料理はとても美味しかったです。
 1	しかも	然も	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカモ,然も,しかも,しかも,シカモ,,,シカモ,シカモ,然も
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -369,6 +381,7 @@
 
 # newdoc id = dev-s14
 # sent_id = dev-s14
+# parallel_id = jagsd/dev14
 # text = 取り調べ段階では黙秘を貫き“全ては裁判官の前で話す”としていた被告は,犯行を認めたものの教祖への逮捕状発布の経緯に関し“捜査当局の不手際,失態”と元同僚らを非難,法廷は一時元警視の独壇場となった。
 1	取り調べ	取り調べ	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トリシラベ,取り調べ,取り調べ,取り調べ,トリシラベ,,,トリシラベ,トリシラベダンカイ,取り調べ段階
 2	段階	段階	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダンカイ,段階,段階,段階,ダンカイ,,,ダンカイ,トリシラベダンカイ,取り調べ段階
@@ -442,6 +455,7 @@
 
 # newdoc id = dev-s15
 # sent_id = dev-s15
+# parallel_id = jagsd/dev15
 # text = 今回、日本のメディアもこのテストに参加することができたので、最新バージョンの出来具合をレポートしていきたい。
 1	今回	今回	ADV	名詞-普通名詞-副詞可能	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=コンカイ,今回,今回,今回,コンカイ,,,コンカイ,コンカイ,今回
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -476,6 +490,7 @@
 
 # newdoc id = dev-s16
 # sent_id = dev-s16
+# parallel_id = jagsd/dev16
 # text = 大正期から、ノンフィクション、推理小説などを訳した。
 1	大正	大正	PROPN	名詞-固有名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タイショウ,大正,大正,大正,タイショー,,,タイショウ,タイショウキ,大正期
 2	期	期	NOUN	名詞-普通名詞-助数詞可能	_	11	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キ,期,期,期,キ,,,キ,タイショウキ,大正期
@@ -493,6 +508,7 @@
 
 # newdoc id = dev-s17
 # sent_id = dev-s17
+# parallel_id = jagsd/dev17
 # text = 市内のユダヤ人は1942年までにその全員が逃亡するか、強制収容所に送致されるかのいずれかであった。
 1	市内	市内	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シナイ,市内,市内,市内,シナイ,,,シナイ,シナイ,市内
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -528,6 +544,7 @@
 
 # newdoc id = dev-s18
 # sent_id = dev-s18
+# parallel_id = jagsd/dev18
 # text = ほとんどは浅海生だが、水深数百mほどの深海まで生息するものもいる。
 1	ほとんど	殆ど	NOUN	名詞-普通名詞-副詞可能	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホトンド,殆ど,ほとんど,ほとんど,ホトンド,,,ホトンド,ホトンド,殆ど
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -552,6 +569,7 @@
 
 # newdoc id = dev-s19
 # sent_id = dev-s19
+# parallel_id = jagsd/dev19
 # text = 価格に見合う満足感を感じます。
 1	価格	価格	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カカク,価格,価格,価格,カカク,,,カカク,カカク,価格
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -565,6 +583,7 @@
 
 # newdoc id = dev-s20
 # sent_id = dev-s20
+# parallel_id = jagsd/dev20
 # text = 一方B国では輸出により小麦の量が減るので、小麦の価格は上がる。
 1	一方	一方	CCONJ	接続詞	_	21	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	B	B	NOUN	記号-文字	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ビー,Ｂ,B,B,ビー,,,ビー,ビーコク,B国
@@ -591,6 +610,7 @@
 
 # newdoc id = dev-s21
 # sent_id = dev-s21
+# parallel_id = jagsd/dev21
 # text = インターナショナル・マネジメント・グループをはじめとする投資家によって所有しているが、中でも元テニス選手ピート・サンプラスとアンドレ・アガシも投資されている。
 1	インターナショナル	インターナショナル	NOUN	名詞-普通名詞-形状詞可能	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=インターナショナル,インターナショナル,インターナショナル,インターナショナル,インターナショナル,,,インターナショナル,インターナショナルマネージメントグループ,インターナショナル・マネージメント・グループ
 2	・	・	SYM	補助記号-一般	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,インターナショナルマネージメントグループ,インターナショナル・マネージメント・グループ
@@ -635,6 +655,7 @@
 
 # newdoc id = dev-s22
 # sent_id = dev-s22
+# parallel_id = jagsd/dev22
 # text = 聖書に当てはめた場合、最も分かりやすいのがノアの方舟伝説である。
 1	聖書	聖書	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイショ,聖書,聖書,聖書,セーショ,,,セイショ,セイショ,聖書
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -657,6 +678,7 @@
 
 # newdoc id = dev-s23
 # sent_id = dev-s23
+# parallel_id = jagsd/dev23
 # text = 海は油膜を貼って青白く光っており、無数の漂着物が流れている。
 1	海	海	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ウミ,海,海,海,ウミ,,,ウミ,ウミ,海
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -681,6 +703,7 @@
 
 # newdoc id = dev-s24
 # sent_id = dev-s24
+# parallel_id = jagsd/dev24
 # text = 一つに,書籍や講演会,施設,HPなどで教祖と幹部の本音,生活,人間性などの真実の情報を手に入れることです。
 1	一	一	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ヒト,一,一,一,ヒト,,,ヒト,ヒトツ,一つ
 2	つ	つ	NOUN	接尾辞-名詞的-助数詞	_	34	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ツ,つ,つ,つ,ツ,,,ツ,ヒトツ,一つ
@@ -721,6 +744,7 @@
 
 # newdoc id = dev-s25
 # sent_id = dev-s25
+# parallel_id = jagsd/dev25
 # text = 麺棒は直径2~3cm、長さ1m程度のものが一般的という。
 1	麺棒	麺棒	NOUN	名詞-普通名詞-一般	_	20	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=メンボウ,麺棒,麺棒,麺棒,メンボー,,,メンボウ,メンボウ,麺棒
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -746,6 +770,7 @@
 
 # newdoc id = dev-s26
 # sent_id = dev-s26
+# parallel_id = jagsd/dev26
 # text = グレたのは、母を亡くし父が仕事で忙しい事が原因らしい。
 1	グレ	ぐれる	VERB	動詞-一般-下一段-ラ行	_	16	csubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-下一段-ラ行|SpaceAfter=No|UnidicInfo=グレル,ぐれる,グレ,グレる,グレ,,,グレル,グレル,ぐれる
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-タ|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -768,6 +793,7 @@
 
 # newdoc id = dev-s27
 # sent_id = dev-s27
+# parallel_id = jagsd/dev27
 # text = スタッフさんも親切に接してくれたので、緊張せずに居心地が良かったです。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフサン,スタッフさん
 2	さん	さん	NOUN	接尾辞-名詞的-一般	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サン,さん,さん,さん,サン,,,サン,スタッフサン,スタッフさん
@@ -794,6 +820,7 @@
 
 # newdoc id = dev-s28
 # sent_id = dev-s28
+# parallel_id = jagsd/dev28
 # text = 元広島県議会議員。
 1	元	元	NOUN	名詞-普通名詞-一般	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=モト,元,元,元,モト,,,モト,モトヒロシマケンギカイギイン,元広島県議会議員
 2	広島	広島	PROPN	名詞-固有名詞-地名-一般	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒロシマ,ヒロシマ,広島,広島,ヒロシマ,,,ヒロシマ,モトヒロシマケンギカイギイン,元広島県議会議員
@@ -804,6 +831,7 @@
 
 # newdoc id = dev-s29
 # sent_id = dev-s29
+# parallel_id = jagsd/dev29
 # text = 地域別では「高台」を選んだのは田老66・0%、仙台39・6%と地域差が大きかった。
 1	地域	地域	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チイキ,地域,地域,地域,チイキ,,,チイキ,チイキベツ,地域別
 2	別	別	NOUN	名詞-普通名詞-形状詞可能	_	28	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ベツ,別,別,別,ベツ,,,ベツ,チイキベツ,地域別
@@ -838,6 +866,7 @@
 
 # newdoc id = dev-s30
 # sent_id = dev-s30
+# parallel_id = jagsd/dev30
 # text = 演芸では,昨年の後夜祭で大受けをとった米粒写経が登場。
 1	演芸	演芸	NOUN	名詞-普通名詞-一般	_	18	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エンゲイ,演芸,演芸,演芸,エンゲー,,,エンゲイ,エンゲイ,演芸
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -861,6 +890,7 @@
 
 # newdoc id = dev-s31
 # sent_id = dev-s31
+# parallel_id = jagsd/dev31
 # text = ロングヘアーの色黒の女性。
 1	ロング	ロング	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ロング,ロング,ロング,ロング,ロング,,,ロング,ロングヘアー,ロングヘアー
 2	ヘアー	ヘア	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヘア,ヘア,ヘアー,ヘアー,ヘアー,,,ヘアー,ロングヘアー,ロングヘアー
@@ -872,6 +902,7 @@
 
 # newdoc id = dev-s33
 # sent_id = dev-s33
+# parallel_id = jagsd/dev33
 # text = ここ数年,統一教会の関連会社による霊感商法で信者の逮捕者が続出しています。
 1	ここ	此処	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
 2	数	数	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=スウ,数,数,数,スー,,,スウ,スウネン,数年
@@ -901,6 +932,7 @@
 
 # newdoc id = dev-s34
 # sent_id = dev-s34
+# parallel_id = jagsd/dev34
 # text = やはり、個室って隔たりがあるのでプライベートな話やビジネスの大事な話もお食事やお酒を飲みながらできるというのがとても大きなメリットであることが分かりました。
 1	やはり	矢張り	ADV	副詞	_	40	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ヤハリ,矢張り,やはり,やはり,ヤハリ,,,ヤハリ,ヤハリ,矢張り
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -948,6 +980,7 @@
 
 # newdoc id = dev-s35
 # sent_id = dev-s35
+# parallel_id = jagsd/dev35
 # text = 精神科へ通院する人の中には、病院へ通院したり予約時間までの間待ち続けるだけでも消耗する人もいます。
 1	精神	精神	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイシン,精神,精神,精神,セーシン,,,セイシン,セイシンカ,精神科
 2	科	科	NOUN	接尾辞-名詞的-一般	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カ,科,科,科,カ,,,カ,セイシンカ,精神科
@@ -985,6 +1018,7 @@
 
 # newdoc id = dev-s36
 # sent_id = dev-s36
+# parallel_id = jagsd/dev36
 # text = また、前年16本だったホームランは19本まで増えた。
 1	また	又	CCONJ	接続詞	_	14	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1005,6 +1039,7 @@
 
 # newdoc id = dev-s37
 # sent_id = dev-s37
+# parallel_id = jagsd/dev37
 # text = 久しぶりにうまいコーヒーが飲めました。
 1	久し	久しい	ADJ	形容詞-一般-形容詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒサシイ,久しい,久し,久しい,ヒサシ,,,ヒサシイ,ヒサシブリ,久し振り
 2	ぶり	振り	NOUN	接尾辞-名詞的-一般	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ブリ,振り,ぶり,ぶり,ブリ,,,ブリ,ヒサシブリ,久し振り
@@ -1019,6 +1054,7 @@
 
 # newdoc id = dev-s38
 # sent_id = dev-s38
+# parallel_id = jagsd/dev38
 # text = これはほとんどのユーザーには問題なかったが、一部のゲームではコピープロテクト用の未フォーマット領域やディスクにたくさんのデータを詰め込む方法として拡張トラックを使用しており、カスタムフォーマットユーティリティでは80トラックのディスクに86のトラックを作るフォーマットが容量拡張の手段として一般的に選べた。
 1	これ	此れ	PRON	代名詞	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1097,6 +1133,7 @@
 
 # newdoc id = dev-s39
 # sent_id = dev-s39
+# parallel_id = jagsd/dev39
 # text = 現在は空き名跡となっている。
 1	現在	現在	NOUN	名詞-普通名詞-副詞可能	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1110,6 +1147,7 @@
 
 # newdoc id = dev-s40
 # sent_id = dev-s40
+# parallel_id = jagsd/dev40
 # text = 元文3年の一門家新設時は加治木家と垂水家がこの家格とされたが、同年に成立した重富家も加わり、重富家の前身、越前島津家が室町幕府の直勤だったため、一門家筆頭とされた。
 1	元文	元文	PROPN	名詞-固有名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ゲンブン,元文,元文,元文,ゲンブン,,,ゲンブン,ゲンブン,元文
 2	3	3	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=サン,三,3,3,サン,,,サン,サンネン,3年
@@ -1172,6 +1210,7 @@
 
 # newdoc id = dev-s41
 # sent_id = dev-s41
+# parallel_id = jagsd/dev41
 # text = 色の指定にtealと指定すると、16進数表記で#008080と表現される色が発色される。
 1	色	色	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イロ,色,色,色,イロ,,,イロ,イロ,色
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1203,6 +1242,7 @@
 
 # newdoc id = dev-s42
 # sent_id = dev-s42
+# parallel_id = jagsd/dev42
 # text = 晩年は霧ケ峰牧場で余生を過ごしたといわれている。
 1	晩年	晩年	NOUN	名詞-普通名詞-副詞可能	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バンネン,晩年,晩年,晩年,バンネン,,,バンネン,バンネン,晩年
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1222,6 +1262,7 @@
 
 # newdoc id = dev-s43
 # sent_id = dev-s43
+# parallel_id = jagsd/dev43
 # text = 以上の操作を再帰的に繰り返すと以下のような決定木が出力される。
 1	以上	以上	NOUN	名詞-普通名詞-副詞可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イジョウ,以上,以上,以上,イジョー,,,イジョウ,イジョウ,以上
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1246,6 +1287,7 @@
 
 # newdoc id = dev-s44
 # sent_id = dev-s44
+# parallel_id = jagsd/dev44
 # text = どこにするか迷ってる方がいたら、ぜひともここをオススメします。
 1	どこ	何処	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ドコ,何処,どこ,どこ,ドコ,,,ドコ,ドコ,何処
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1270,6 +1312,7 @@
 
 # newdoc id = dev-s45
 # sent_id = dev-s45
+# parallel_id = jagsd/dev45
 # text = これはおそらくタバコを普及させたウォルター・ローリー卿が伝説の黄金の都市エル・ドラードを求めてガイアナのオリノコ川を遡った1580年の遠征の栄誉を称えたものと見られている。
 1	これ	此れ	PRON	代名詞	_	42	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1320,6 +1363,7 @@
 
 # newdoc id = dev-s46
 # sent_id = dev-s46
+# parallel_id = jagsd/dev46
 # text = 16日の東京株式市場も主力輸出株はさえない。
 1	16	16	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一六,16,16,イチロク,,,イチロク,イチロクニチ,16日
 2	日	日	NOUN	名詞-普通名詞-助数詞可能	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニチ,日,日,日,ニチ,,,ニチ,イチロクニチ,16日
@@ -1338,6 +1382,7 @@
 
 # newdoc id = dev-s47
 # sent_id = dev-s47
+# parallel_id = jagsd/dev47
 # text = これらが順に収縮することで食物を胃に送り出すような動きをする。
 1	これ	此れ	PRON	代名詞	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレラ,此れ等
 2	ら	等	NOUN	接尾辞-名詞的-一般	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ラ,等,ら,ら,ラ,,,ラ,コレラ,此れ等
@@ -1362,6 +1407,7 @@
 
 # newdoc id = dev-s48
 # sent_id = dev-s48
+# parallel_id = jagsd/dev48
 # text = 実際廃止された区間の復旧再開も京義・東海線とともに検討され、1991年にすでに用地買取や設計などが済まされていたが、地形的理由で見送られてきた。
 1	実際	実際	ADV	名詞-普通名詞-副詞可能	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ジッサイ,実際,実際,実際,ジッサイ,,,ジッサイ,ジッサイ,実際
 2	廃止	廃止	VERB	名詞-普通名詞-サ変可能	_	6	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=ハイシ,廃止,廃止,廃止,ハイシ,,,ハイシ,ハイシスル,廃止する
@@ -1414,6 +1460,7 @@
 
 # newdoc id = dev-s49
 # sent_id = dev-s49
+# parallel_id = jagsd/dev49
 # text = 蔵前国技館跡地は東京都に売却し、その売却益が両国国技館建設の資金となった。
 1	蔵前	蔵前	PROPN	名詞-固有名詞-地名-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クラマエ,クラマエ,蔵前,蔵前,クラマエ,,,クラマエ,クラマエコクギカンアトチ,蔵前国技館跡地
 2	国技	国技	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コクギ,国技,国技,国技,コクギ,,,コクギ,クラマエコクギカンアトチ,蔵前国技館跡地
@@ -1443,6 +1490,7 @@
 
 # newdoc id = dev-s50
 # sent_id = dev-s50
+# parallel_id = jagsd/dev50
 # text = ヴィクトル・ユゴーなどフランス・ロマン派を専門とした。
 1	ヴィクトル	ヴィクトル	PROPN	名詞-固有名詞-人名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ビクトル,ビクトル,ヴィクトル,ヴィクトル,ビクトル,,,ビクトル,ビクトルユゴー,ヴィクトル・ユゴー
 2	・	・	SYM	補助記号-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,ビクトルユゴー,ヴィクトル・ユゴー
@@ -1461,6 +1509,7 @@
 
 # newdoc id = dev-s51
 # sent_id = dev-s51
+# parallel_id = jagsd/dev51
 # text = イーアスの中にある映画館なので、駐車場が広いのもGood。
 1	イーアス	イーアス	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=イーアス,イーアス,イーアス,イーアス,イーアス,,,イーアス,イーアス,イーアス
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1484,6 +1533,7 @@
 
 # newdoc id = dev-s52
 # sent_id = dev-s52
+# parallel_id = jagsd/dev52
 # text = 府中や国立の辺りの土地が得意とのことで、色々と紹介してもらうことができました。
 1	府中	府中	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=フチュウ,フチュウ,府中,府中,フチュー,,,フチュウ,フチュウ,府中
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -1514,6 +1564,7 @@
 
 # newdoc id = dev-s53
 # sent_id = dev-s53
+# parallel_id = jagsd/dev53
 # text = 日本貝類学会役員、東京貝類同好会名誉会長を務めた貝類収集家としても知られた。
 1	日本	日本	PROPN	名詞-固有名詞-地名-国	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニッポン,,,ニッポン,ニッポンカイルイガッカイヤクイン,日本介類学会役員
 2	貝類	介類	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイルイ,介類,貝類,貝類,カイルイ,,,カイルイ,ニッポンカイルイガッカイヤクイン,日本介類学会役員
@@ -1543,6 +1594,7 @@
 
 # newdoc id = dev-s54
 # sent_id = dev-s54
+# parallel_id = jagsd/dev54
 # text = 富士通は、産業機械だけでなく、社会インフラや物流業界などに対してM2Mサービスを提供する。
 1	富士通	富士通	PROPN	名詞-固有名詞-一般	_	23	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=フジツウ,富士通,富士通,富士通,フジツー,,,フジツウ,フジツウ,富士通
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1572,6 +1624,7 @@
 
 # newdoc id = dev-s55
 # sent_id = dev-s55
+# parallel_id = jagsd/dev55
 # text = 第一次世界大戦終結後、ヴェルサイユ条約によって大砲の保有を禁止されたドイツから戦争賠償としてベルギーが残存砲を接収して装備した。
 1	第	第	NOUN	接頭辞	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ダイ,第,第,第,ダイ,,,ダイ,ダイイチジセカイタイセンシュウケツゴ,第一次世界大戦終結後
 2	一	一	NUM	名詞-数詞	_	7	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イチ,一,一,一,イチ,,,イチ,ダイイチジセカイタイセンシュウケツゴ,第一次世界大戦終結後
@@ -1616,6 +1669,7 @@
 
 # newdoc id = dev-s56
 # sent_id = dev-s56
+# parallel_id = jagsd/dev56
 # text = やはり、おすすめは焼き物ですね。
 1	やはり	矢張り	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ヤハリ,矢張り,やはり,やはり,ヤハリ,,,ヤハリ,ヤハリ,矢張り
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -1629,6 +1683,7 @@
 
 # newdoc id = dev-s57
 # sent_id = dev-s57
+# parallel_id = jagsd/dev57
 # text = いなべ市藤原町坂本-同市藤原町下野尻を以下の路線バスが通過する。
 1	いなべ	いなべ	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=イナベ,イナベ,いなべ,いなべ,イナベ,,,イナベ,イナベシ,いなべ市
 2	市	市	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=シ,市,市,市,シ,,,シ,イナベシ,いなべ市
@@ -1652,6 +1707,7 @@
 
 # newdoc id = dev-s58
 # sent_id = dev-s58
+# parallel_id = jagsd/dev58
 # text = ロイツェは沖縄戦終結後の7月10日に慶良間を離れてグアム、真珠湾を経由してサンフランシスコに到着し、8月3日からハンターズ・ポイント海軍造船所で修理が開始されたが、終戦により修理は停止された。
 1	ロイツェ	ロイツェ	PROPN	名詞-固有名詞-人名-一般	_	27	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ロイツェ,ロイツェ,ロイツェ,ロイツェ,ロイツェ,,,ロイツェ,ロイツェ,ロイツェ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1715,6 +1771,7 @@
 
 # newdoc id = dev-s59
 # sent_id = dev-s59
+# parallel_id = jagsd/dev59
 # text = その際,国会議員に対して請願を行う予定と見られています。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	際	際	NOUN	名詞-普通名詞-副詞可能	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サイ,際,際,際,サイ,,,サイ,サイ,際
@@ -1738,6 +1795,7 @@
 
 # newdoc id = dev-s60
 # sent_id = dev-s60
+# parallel_id = jagsd/dev60
 # text = かつては、農業が圧倒的で、バーデン=ヴュルテンベルク州内で最も脆弱な経済基盤の郡であったが、近年は構造変化を成し遂げている。
 1	かつて	嘗て	ADV	副詞	_	21	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=カツテ,嘗て,かつて,かつて,カツテ,,,カツテ,カツテ,嘗て
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1777,6 +1835,7 @@
 
 # newdoc id = dev-s61
 # sent_id = dev-s61
+# parallel_id = jagsd/dev61
 # text = 人を人として思わないような,尋常ではないこの現実をみなさんにお伝えしたいのです。
 1	人	人	NOUN	名詞-普通名詞-一般	_	7	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒト,人,人,人,ヒト,,,ヒト,ヒト,人
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -1809,6 +1868,7 @@
 
 # newdoc id = dev-s62
 # sent_id = dev-s62
+# parallel_id = jagsd/dev62
 # text = ハンマーはやめて!
 1	ハンマー	ハンマー	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハンマー,ハンマー,ハンマー,ハンマー,ハンマー,,,ハンマー,ハンマー,ハンマー
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1818,6 +1878,7 @@
 
 # newdoc id = dev-s63
 # sent_id = dev-s63
+# parallel_id = jagsd/dev63
 # text = 大きな拍手が巻き起こりました。
 1	大きな	大きな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=オオキナ,大きな,大きな,大きな,オーキナ,,,オオキナ,オオキナ,大きな
 2	拍手	拍手	NOUN	名詞-普通名詞-サ変可能	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハクシュ,拍手,拍手,拍手,ハクシュ,,,ハクシュ,ハクシュ,拍手
@@ -1829,6 +1890,7 @@
 
 # newdoc id = dev-s64
 # sent_id = dev-s64
+# parallel_id = jagsd/dev64
 # text = リミテッド・シリーズの『マーベル1602』で、「スティーブン・ストレンジ卿」は専属医師兼魔術師としてエリザベス1世に仕えた。
 1	リミテッド	リミテッド	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=リミテッド,リミテッド,リミテッド,リミテッド,リミテッド,,,リミテッド,リミテッドシリーズ,リミテッド・シリーズ
 2	・	・	SYM	補助記号-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,リミテッドシリーズ,リミテッド・シリーズ
@@ -1865,6 +1927,7 @@
 
 # newdoc id = dev-s65
 # sent_id = dev-s65
+# parallel_id = jagsd/dev65
 # text = 果肉は橙色で、肉質はやや硬いが多汁である。
 1	果肉	果肉	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カニク,果肉,果肉,果肉,カニク,,,カニク,カニク,果肉
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1883,6 +1946,7 @@
 
 # newdoc id = dev-s66
 # sent_id = dev-s66
+# parallel_id = jagsd/dev66
 # text = 戸籍上は女性として生まれたが、幼い頃から「自分は男性である」との性自認を持っていた。
 1	戸籍	戸籍	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コセキ,戸籍,戸籍,戸籍,コセキ,,,コセキ,コセキジョウ,戸籍上
 2	上	上	NOUN	接尾辞-名詞的-副詞可能	_	8	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョウ,上,上,上,ジョー,,,ジョウ,コセキジョウ,戸籍上
@@ -1918,6 +1982,7 @@
 
 # newdoc id = dev-s67
 # sent_id = dev-s67
+# parallel_id = jagsd/dev67
 # text = 中日新聞社が後援している。
 1	中日	中日	PROPN	名詞-固有名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=チュウニチ,中日,中日,中日,チューニチ,,,チュウニチ,チュウニチシンブンシャ,中日新聞社
 2	新聞	新聞	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=シンブン,新聞,新聞,新聞,シンブン,,,シンブン,チュウニチシンブンシャ,中日新聞社
@@ -1931,6 +1996,7 @@
 
 # newdoc id = dev-s68
 # sent_id = dev-s68
+# parallel_id = jagsd/dev68
 # text = カラフルで色合いがいいデザインがあったので気に入りました。
 1	カラフル	カラフル	ADJ	形状詞-一般	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=カラフル,カラフル,カラフル,カラフル,カラフル,,,カラフル,カラフル,カラフル
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -1952,6 +2018,7 @@
 
 # newdoc id = dev-s69
 # sent_id = dev-s69
+# parallel_id = jagsd/dev69
 # text = クルマにまつわるエピソードをTwitterで投稿する同キャンペーン。
 1	クルマ	車	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クルマ,車,クルマ,クルマ,クルマ,,,クルマ,クルマ,車
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1968,6 +2035,7 @@
 
 # newdoc id = dev-s70
 # sent_id = dev-s70
+# parallel_id = jagsd/dev70
 # text = ビッグ・モーラが破壊されたときには、彼らの策略のために、既にかつての威光はなくなっていた。
 1	ビッグ	ビッグ	ADJ	形状詞-一般	_	3	amod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ビッグ,ビッグ,ビッグ,ビッグ,ビッグ,,,ビッグ,ビッグモーラ,ビッグ・モーラ
 2	・	・	SYM	補助記号-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,ビッグモーラ,ビッグ・モーラ
@@ -2002,6 +2070,7 @@
 
 # newdoc id = dev-s71
 # sent_id = dev-s71
+# parallel_id = jagsd/dev71
 # text = 北朝鮮についてはホームでの対戦もすんなりとはいかない。
 1	北朝鮮	北朝鮮	PROPN	名詞-固有名詞-地名-国	_	14	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=キタチョウセン,北朝鮮,北朝鮮,北朝鮮,キタチョーセン,,,キタチョウセン,キタチョウセン,北朝鮮
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニツイテ,について
@@ -2022,6 +2091,7 @@
 
 # newdoc id = dev-s72
 # sent_id = dev-s72
+# parallel_id = jagsd/dev72
 # text = 定期的にイベントしてるらしくて要チェックです。
 1	定期	定期	NOUN	名詞-普通名詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=テイキ,定期,定期,定期,テーキ,,,テイキ,テイキテキ,定期的
 2	的	的	PART	接尾辞-形状詞的	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=テキ,的,的,的,テキ,,,テキ,テイキテキ,定期的
@@ -2038,6 +2108,7 @@
 
 # newdoc id = dev-s73
 # sent_id = dev-s73
+# parallel_id = jagsd/dev73
 # text = 中日の次期監督に決まっている高木守道氏からラブコールを送られている福留に、巨人も再び手を伸ばすことになるかどうか。
 1	中日	中日	PROPN	名詞-固有名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=チュウニチ,中日,中日,中日,チューニチ,,,チュウニチ,チュウニチ,中日
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2077,6 +2148,7 @@
 
 # newdoc id = dev-s74
 # sent_id = dev-s74
+# parallel_id = jagsd/dev74
 # text = 施設は大阪市が所有し、指定管理者は財団法人大阪市スポーツ・みどり振興協会である。
 1	施設	施設	NOUN	名詞-普通名詞-サ変可能	_	6	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シセツ,施設,施設,施設,シセツ,,,シセツ,シセツ,施設
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2105,6 +2177,7 @@
 
 # newdoc id = dev-s75
 # sent_id = dev-s75
+# parallel_id = jagsd/dev75
 # text = 私は住民に事実を伝えるのが仕事ですから。
 1	私	私	PRON	代名詞	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2122,6 +2195,7 @@
 
 # newdoc id = dev-s76
 # sent_id = dev-s76
+# parallel_id = jagsd/dev76
 # text = ヨーロッパ各国の航空機メーカのコンソーシアムであるエアバス社は、政治的な理由によりヨーロッパ各地に部品工場を保有しており、最終組み立てのため機体部品の輸送が課題であった。
 1	ヨーロッパ	ヨーロッパ	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨーロッパ,ヨーロッパ,ヨーロッパ,ヨーロッパ,ヨーロッパ,,,ヨーロッパ,ヨーロッパカッコク,ヨーロッパ各国
 2	各国	各国	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カッコク,各国,各国,各国,カッコク,,,カッコク,ヨーロッパカッコク,ヨーロッパ各国
@@ -2171,6 +2245,7 @@
 
 # newdoc id = dev-s77
 # sent_id = dev-s77
+# parallel_id = jagsd/dev77
 # text = 途中でジュールが亡くなったため兄エドモンが完成。
 1	途中	途中	NOUN	名詞-普通名詞-副詞可能	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トチュウ,途中,途中,途中,トチュー,,,トチュウ,トチュウ,途中
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -2187,6 +2262,7 @@
 
 # newdoc id = dev-s78
 # sent_id = dev-s78
+# parallel_id = jagsd/dev78
 # text = 同社の不燃木材は浅野木材工業の浅野成昭が開発し、2001年に日本で初めて国土交通省から不燃材料の認定を受けた。
 1	同社	同社	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウシャ,同社,同社,同社,ドーシャ,,,ドウシャ,ドウシャ,同社
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2224,6 +2300,7 @@
 
 # newdoc id = dev-s79
 # sent_id = dev-s79
+# parallel_id = jagsd/dev79
 # text = 堀田は仙台藩伊達家を「家元」と宇和島藩伊達家を「家別レ」とするといった調停案を示した。
 1	堀田	堀田	PROPN	名詞-固有名詞-人名-姓	_	29	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=ホッタ,ホッタ,堀田,堀田,ホッタ,,,ホッタ,ホッタ,堀田
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2259,6 +2336,7 @@
 
 # newdoc id = dev-s80
 # sent_id = dev-s80
+# parallel_id = jagsd/dev80
 # text = ホームページが出来たみたいです。
 1	ホーム	ホーム	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホーム,ホーム,ホーム,ホーム,ホーム,,,ホーム,ホームページ,ホームページ
 2	ページ	ページ	NOUN	名詞-普通名詞-助数詞可能	_	4	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ページ,ページ,ページ,ページ,ページ,,,ページ,ホームページ,ホームページ
@@ -2271,6 +2349,7 @@
 
 # newdoc id = dev-s81
 # sent_id = dev-s81
+# parallel_id = jagsd/dev81
 # text = また、10月には販売網の強化と顧客へのサービスの充実を図るため、神奈川県藤沢市に営業所を開設。
 1	また	又	CCONJ	接続詞	_	30	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2306,6 +2385,7 @@
 
 # newdoc id = dev-s82
 # sent_id = dev-s82
+# parallel_id = jagsd/dev82
 # text = JBS日本福祉放送は社会福祉法人“視覚障害者文化振興協会”が運営する視覚障害者専用放送だ。
 1	JBS	JBS	PROPN	名詞-固有名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ジェービーエス,ＪＢＳ,JBS,JBS,ジェービーエス,,,ジェービーエス,ジェービーエスニッポンフクシホウソウ,JBS日本福祉放送
 2	日本	日本	PROPN	名詞-固有名詞-地名-国	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニッポン,,,ニッポン,ジェービーエスニッポンフクシホウソウ,JBS日本福祉放送
@@ -2336,6 +2416,7 @@
 
 # newdoc id = dev-s83
 # sent_id = dev-s83
+# parallel_id = jagsd/dev83
 # text = 1986年より開発はフェイズ2に移行し機体の改修作業が行われた。
 1	1986	1986	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九八六,1986,1986,イチキューハチロク,,,イチキュウハチロク,イチキュウハチロクネン,1986年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	9	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチキュウハチロクネン,1986年
@@ -2359,6 +2440,7 @@
 
 # newdoc id = dev-s84
 # sent_id = dev-s84
+# parallel_id = jagsd/dev84
 # text = 米議会内でもビンラディンが殺害されたことを確認するうえでも公表すべきだとの声が高まっていた。
 1	米	米	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ベイ,米,米,米,ベー,,,ベイ,ベイギカイナイ,米議会内
 2	議会	議会	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ギカイ,議会,議会,議会,ギカイ,,,ギカイ,ベイギカイナイ,米議会内
@@ -2394,6 +2476,7 @@
 
 # newdoc id = dev-s85
 # sent_id = dev-s85
+# parallel_id = jagsd/dev85
 # text = ただし、個別の作品に関する話題はエロゲー作品別板で扱う。
 1	ただし	但し	CCONJ	接続詞	_	14	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2413,6 +2496,7 @@
 
 # newdoc id = dev-s86
 # sent_id = dev-s86
+# parallel_id = jagsd/dev86
 # text = そのような活動を止めるどころか,顕進氏は,自分は創始者と協力しており,真の御父母様の遺されたものを維持しようとしているのだという錯覚を,積極的に助長してきています。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	よう	様	NOUN	形状詞-助動詞語幹	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-助動詞語幹|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=ヨウ,様,よう,よう,ヨー,,,ヨウ,ヨウ,様
@@ -2475,6 +2559,7 @@
 
 # newdoc id = dev-s87
 # sent_id = dev-s87
+# parallel_id = jagsd/dev87
 # text = 私はクートラ医師の所有するストリックランドの果物絵を見て恐ろしさを感じていた。
 1	私	私	PRON	代名詞	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2501,6 +2586,7 @@
 
 # newdoc id = dev-s88
 # sent_id = dev-s88
+# parallel_id = jagsd/dev88
 # text = その保健室の養護教諭が,生徒からバカにされていた様子がうかがえます。
 1	その	其の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	保健	保健	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホケン,保健,保健,保健,ホケン,,,ホケン,ホケンシツ,保健室
@@ -2527,6 +2613,7 @@
 
 # newdoc id = dev-s89
 # sent_id = dev-s89
+# parallel_id = jagsd/dev89
 # text = 今回が初のツアー競技挑戦だ。
 1	今回	今回	NOUN	名詞-普通名詞-副詞可能	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コンカイ,今回,今回,今回,コンカイ,,,コンカイ,コンカイ,今回
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -2540,6 +2627,7 @@
 
 # newdoc id = dev-s90
 # sent_id = dev-s90
+# parallel_id = jagsd/dev90
 # text = やはり、日常的に利用されることが多い業者だけあって、非常に慣れた感じはあります。
 1	やはり	矢張り	ADV	副詞	_	23	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ヤハリ,矢張り,やはり,やはり,ヤハリ,,,ヤハリ,ヤハリ,矢張り
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2569,6 +2657,7 @@
 
 # newdoc id = dev-s91
 # sent_id = dev-s91
+# parallel_id = jagsd/dev91
 # text = 流出したものとされる資料群の中に,“日本における国産テロリストの脅威について”というタイトルのPDFファイルがありました。
 1	流出	流出	VERB	名詞-普通名詞-サ変可能	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=リュウシュツ,流出,流出,流出,リューシュツ,,,リュウシュツ,リュウシュツスル,流出する
 2	し	為る	AUX	動詞-非自立可能-サ行変格	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,リュウシュツスル,流出する
@@ -2610,6 +2699,7 @@
 
 # newdoc id = dev-s92
 # sent_id = dev-s92
+# parallel_id = jagsd/dev92
 # text = しかしながら、中心部の温度は、約5,000°Cである。
 1	しかし	然し	CCONJ	接続詞	_	14	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシナガラ,然しながら
 2	ながら	ながら	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ナガラ,ながら,ながら,ながら,ナガラ,,,ナガラ,シカシナガラ,然しながら
@@ -2631,6 +2721,7 @@
 
 # newdoc id = dev-s93
 # sent_id = dev-s93
+# parallel_id = jagsd/dev93
 # text = 歯のかみ合わせを考えて治療をしてくれる歯科なので、満足のいく治療をしてもらえます。
 1	歯	歯	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハ,歯,歯,歯,ハ,,,ハ,ハ,歯
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2661,6 +2752,7 @@
 
 # newdoc id = dev-s94
 # sent_id = dev-s94
+# parallel_id = jagsd/dev94
 # text = そして、寛永期以降の蝦夷地幕領化の中で「松前稼」と呼ばれた、蝦夷地への労働力移動が可能であり、飢餓期の困窮を一時的に回避することができた。
 1	そして	そして	CCONJ	接続詞	_	43	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2714,6 +2806,7 @@
 
 # newdoc id = dev-s95
 # sent_id = dev-s95
+# parallel_id = jagsd/dev95
 # text = 建設中や計画中のラインがさらに8つあるという。
 1	建設	建設	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケンセツ,建設,建設,建設,ケンセツ,,,ケンセツ,ケンセツチュウ,建設中
 2	中	中	NOUN	接尾辞-名詞的-副詞可能	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チュウ,中,中,中,チュー,,,チュウ,ケンセツチュウ,建設中
@@ -2733,6 +2826,7 @@
 
 # newdoc id = dev-s96
 # sent_id = dev-s96
+# parallel_id = jagsd/dev96
 # text = ぬーとぴあのシェアメイトは、優太を除きなんと全員女性。
 1	ぬーとぴあ	ぬーとぴあ	PROPN	名詞-固有名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ヌートピア,ぬーとぴあ,ぬーとぴあ,ぬーとぴあ,ヌートピア,,,ヌートピア,ヌートピア,ぬーとぴあ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2751,6 +2845,7 @@
 
 # newdoc id = dev-s97
 # sent_id = dev-s97
+# parallel_id = jagsd/dev97
 # text = 体育科2年2組所属の少年。
 1	体育	体育	NOUN	名詞-普通名詞-一般	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タイイク,体育,体育,体育,タイイク,,,タイイク,タイイクカ,体育科
 2	科	科	NOUN	接尾辞-名詞的-一般	_	7	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カ,科,科,科,カ,,,カ,タイイクカ,体育科
@@ -2765,6 +2860,7 @@
 
 # newdoc id = dev-s98
 # sent_id = dev-s98
+# parallel_id = jagsd/dev98
 # text = 誕生日用にホールケーキを予約してくれたのですが、これが美味!
 1	誕生	誕生	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タンジョウ,誕生,誕生,誕生,タンジョー,,,タンジョウ,タンジョウビヨウ,誕生日用
 2	日	日	NOUN	名詞-普通名詞-副詞可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ビ,,,ヒ,タンジョウビヨウ,誕生日用
@@ -2789,6 +2885,7 @@
 
 # newdoc id = dev-s99
 # sent_id = dev-s99
+# parallel_id = jagsd/dev99
 # text = 組内外から高い評価を受けていたやり手で、二代目海江田組では実質的な運営を担っていた。
 1	組	組	NOUN	名詞-普通名詞-助数詞可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クミ,組,組,組,クミ,,,クミ,クミナイガイ,組内外
 2	内外	内外	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナイガイ,内外,内外,内外,ナイガイ,,,ナイガイ,クミナイガイ,組内外
@@ -2823,6 +2920,7 @@
 
 # newdoc id = dev-s100
 # sent_id = dev-s100
+# parallel_id = jagsd/dev100
 # text = 実際はガセの情報だったのだが、レコードは自主回収となり、ナゴム閉社への決定打のひとつとなってしまう。
 1	実際	実際	NOUN	名詞-普通名詞-副詞可能	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジッサイ,実際,実際,実際,ジッサイ,,,ジッサイ,ジッサイ,実際
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2859,6 +2957,7 @@
 
 # newdoc id = dev-s101
 # sent_id = dev-s101
+# parallel_id = jagsd/dev101
 # text = HDCD対応デジフィルの殆ど全てのICでは必ず-1dB絞っているので、通常の音楽CD盤を再生したとき、そのD/A変換回路のフルスケールは用いられていないことになる。
 1	HDCD	HDCD	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エイチディーシーディー,ＨＤＣＤ,HDCD,HDCD,エーチディーシーディー,,,エイチディーシーディー,エイチディーシーディータイオウデジフィル,HDCD対応デジフィル
 2	対応	対応	NOUN	名詞-普通名詞-サ変可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タイオウ,対応,対応,対応,タイオー,,,タイオウ,エイチディーシーディータイオウデジフィル,HDCD対応デジフィル
@@ -2914,6 +3013,7 @@
 
 # newdoc id = dev-s102
 # sent_id = dev-s102
+# parallel_id = jagsd/dev102
 # text = われわれの組織がつぶれれば良いと日共や権力が願望をもっても今のところ手を下す方法がない。
 1	われわれ	我々	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワレワレ,我々,われわれ,われわれ,ワレワレ,,,ワレワレ,ワレワレ,我々
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2945,6 +3045,7 @@
 
 # newdoc id = dev-s103
 # sent_id = dev-s103
+# parallel_id = jagsd/dev103
 # text = 外に出るのは、産後1か月で始めたヨガのレッスンに通う程度。
 1	外	外	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ソト,外,外,外,ソト,,,ソト,ソト,外
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -2968,6 +3069,7 @@
 
 # newdoc id = dev-s104
 # sent_id = dev-s104
+# parallel_id = jagsd/dev104
 # text = 来年の春、すぐ近くにある大きな公園で、子供たちと一緒に桜をみるのが、今からとても楽しみです。
 1	来年	来年	NOUN	名詞-普通名詞-副詞可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ライネン,来年,来年,来年,ライネン,,,ライネン,ライネン,来年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3001,6 +3103,7 @@
 
 # newdoc id = dev-s105
 # sent_id = dev-s105
+# parallel_id = jagsd/dev105
 # text = これは後に本居宣長によって、現在と同じような位置に訂正された。
 1	これ	此れ	PRON	代名詞	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3027,6 +3130,7 @@
 
 # newdoc id = dev-s106
 # sent_id = dev-s106
+# parallel_id = jagsd/dev106
 # text = まんまとお店側の思惑にハマっている私でした。
 1	まんまと	まんまと	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=マンマト,まんまと,まんまと,まんまと,マンマト,,,マンマト,マンマト,まんまと
 2	お	御	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オミセガワ,御店側
@@ -3044,6 +3148,7 @@
 
 # newdoc id = dev-s107
 # sent_id = dev-s107
+# parallel_id = jagsd/dev107
 # text = 小規模の駅前広場を持つ。
 1	小	小	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショウ,小,小,小,ショー,,,ショウ,ショウキボ,小規模
 2	規模	規模	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キボ,規模,規模,規模,キボ,,,キボ,ショウキボ,小規模
@@ -3056,6 +3161,7 @@
 
 # newdoc id = dev-s108
 # sent_id = dev-s108
+# parallel_id = jagsd/dev108
 # text = 身長172cm、体重60kg。
 1	身長	身長	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンチョウ,身長,身長,身長,シンチョー,,,シンチョウ,シンチョウ,身長
 2	172	172	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一七二,172,172,イチナナニ,,,イチナナニ,イチナナニセンチメートル,172cm
@@ -3068,6 +3174,7 @@
 
 # newdoc id = dev-s109
 # sent_id = dev-s109
+# parallel_id = jagsd/dev109
 # text = 胸部は格納庫になっており、弾薬など物資を積むことが可能。
 1	胸部	胸部	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウブ,胸部,胸部,胸部,キョーブ,,,キョウブ,キョウブ,胸部
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3090,6 +3197,7 @@
 
 # newdoc id = dev-s110
 # sent_id = dev-s110
+# parallel_id = jagsd/dev110
 # text = このような大型のゲル、大型のゲルを中心とした遊牧民の宮廷のことをふつうオルドと呼んでおり、モンゴル帝国のハーンたちは非常に大きなゲルをオルドとしていたことが知られる。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	よう	様	NOUN	形状詞-助動詞語幹	_	6	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-助動詞語幹|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=ヨウ,様,よう,よう,ヨー,,,ヨウ,ヨウ,様
@@ -3145,6 +3253,7 @@
 
 # newdoc id = dev-s111
 # sent_id = dev-s111
+# parallel_id = jagsd/dev111
 # text = 2011年3月期にLED関連照明事業で22億円の売り上げを目指す。
 1	2011	2011	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロ一一,2011,2011,ニゼロイチイチ,,,ニゼロイチイチ,ニゼロイチイチネン,2011年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロイチイチネン,2011年
@@ -3168,6 +3277,7 @@
 
 # newdoc id = dev-s112
 # sent_id = dev-s112
+# parallel_id = jagsd/dev112
 # text = 1987年の第1回授賞式以来、この賞はアフリカ系アメリカ人のミュージシャンにとって、大変重要な存在となっている。
 1	1987	1987	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九八七,1987,1987,イチキューハチシチ,,,イチキュウハチシチ,イチキュウハチシチネン,1987年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	9	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチキュウハチシチネン,1987年
@@ -3204,6 +3314,7 @@
 
 # newdoc id = dev-s113
 # sent_id = dev-s113
+# parallel_id = jagsd/dev113
 # text = また同小説では藍染になすりつけられた罪は、元柳斎の尽力もあって藍染の謀略が認められたことから鉄裁・夜一の罪状共々取り消しとなったこと、商店も尸魂界公認となった上、破面篇で喜助の存在が広く知れ渡った為、現世駐在任務の死神が多数訪れるように手が足りなくなりつつある程忙しくなっていることが語られている。
 1	また	又	CCONJ	接続詞	_	88	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	同	同	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウ,同,同,同,ドー,,,ドウ,ドウショウセツ,同小説
@@ -3300,6 +3411,7 @@
 
 # newdoc id = dev-s114
 # sent_id = dev-s114
+# parallel_id = jagsd/dev114
 # text = また、未来の高度に進化した人工知能は本質的に自己書き換えを行うはずだと主張する者もいる。
 1	また	又	CCONJ	接続詞	_	27	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3332,6 +3444,7 @@
 
 # newdoc id = dev-s115
 # sent_id = dev-s115
+# parallel_id = jagsd/dev115
 # text = 体表面は水にぬれても毛の根元は油分により撥水効果をもち、これにより野生動物などは厳しい環境の寒暖の変化から体内の恒常性を守っている。
 1	体表	体表	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タイヒョウ,体表,体表,体表,タイヒョー,,,タイヒョウ,タイヒョウメン,体表面
 2	面	面	NOUN	名詞-普通名詞-助数詞可能	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=メン,面,面,面,メン,,,メン,タイヒョウメン,体表面
@@ -3379,6 +3492,7 @@
 
 # newdoc id = dev-s116
 # sent_id = dev-s116
+# parallel_id = jagsd/dev116
 # text = 形態としてはコンビニATMに類似している。
 1	形態	形態	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケイタイ,形態,形態,形態,ケータイ,,,ケイタイ,ケイタイ,形態
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,トシテ,として
@@ -3396,6 +3510,7 @@
 
 # newdoc id = dev-s117
 # sent_id = dev-s117
+# parallel_id = jagsd/dev117
 # text = 生まれついて“針”を持っており、それが彼女の能力に反映されている。
 1	生まれつい	生まれ付く	VERB	動詞-一般-五段-カ行	_	7	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-カ行|SpaceAfter=No|UnidicInfo=ウマレツク,生まれ付く,生まれつい,生まれつく,ウマレツイ,,,ウマレツク,ウマレツク,生まれ付く
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-接続助詞|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -3422,6 +3537,7 @@
 
 # newdoc id = dev-s118
 # sent_id = dev-s118
+# parallel_id = jagsd/dev118
 # text = 「CS 5」シリーズの中でもWebデザイナー向け製品である「Web Premium」に含まれるアプリケーションについての全体像と、それぞれの製品の役割について紹介していこう。
 1	「	「	PUNCT	補助記号-括弧開	_	5	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	CS	CS	NOUN	名詞-普通名詞-一般	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|UnidicInfo=シーエス,ＣＳ,CS,CS,シーエス,,,シーエス,シーエスファイブ,CS5
@@ -3470,6 +3586,7 @@
 
 # newdoc id = dev-s119
 # sent_id = dev-s119
+# parallel_id = jagsd/dev119
 # text = 日本基督教団阿佐ヶ谷教会の牧師を務める。
 1	日本	日本	PROPN	名詞-固有名詞-地名-国	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニホン,,,ニホン,ニホンキリストキョウダンアサガヤキョウカイ,日本基督教団阿佐ヶ谷教会
 2	基督	基督	PROPN	名詞-固有名詞-人名-一般	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キリスト,キリスト,基督,基督,キリスト,,,キリスト,ニホンキリストキョウダンアサガヤキョウカイ,日本基督教団阿佐ヶ谷教会
@@ -3484,6 +3601,7 @@
 
 # newdoc id = dev-s120
 # sent_id = dev-s120
+# parallel_id = jagsd/dev120
 # text = 405法廷,吉田被告は前回公判時の手錠に腰縄の姿とは異なり上下黒のスーツ姿で現れた。
 1	405	405	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨン,四ゼロ五,405,405,ヨンゼロゴ,,,ヨンゼロゴ,ヨンゼロゴホウテイ,405法廷
 2	法廷	法廷	NOUN	名詞-普通名詞-一般	_	25	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホウテイ,法廷,法廷,法廷,ホーテー,,,ホウテイ,ヨンゼロゴホウテイ,405法廷
@@ -3515,6 +3633,7 @@
 
 # newdoc id = dev-s121
 # sent_id = dev-s121
+# parallel_id = jagsd/dev121
 # text = まず予選7位の#1 ポルシェが抜群のスタートを決め、オープニングラップのグランプリコースの間にトップに浮上。
 1	まず	先ず	ADV	副詞	_	14	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=マズ,先ず,まず,まず,マズ,,,マズ,マズ,先ず
 2	予選	予選	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨセン,予選,予選,予選,ヨセン,,,ヨセン,ヨセン,予選
@@ -3546,6 +3665,7 @@
 
 # newdoc id = dev-s122
 # sent_id = dev-s122
+# parallel_id = jagsd/dev122
 # text = バイオリン弓毛替をやっています。
 1	バイオリン	バイオリン	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バイオリン,バイオリン,バイオリン,バイオリン,バイオリン,,,バイオリン,バイオリンユミゲカエ,バイオリン弓毛替え
 2	弓毛	弓毛	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ユミゲ,弓毛,弓毛,弓毛,ユミゲ,,,ユミゲ,バイオリンユミゲカエ,バイオリン弓毛替え
@@ -3559,6 +3679,7 @@
 
 # newdoc id = dev-s123
 # sent_id = dev-s123
+# parallel_id = jagsd/dev123
 # text = 施設に宿泊した人もいたようです。
 1	施設	施設	NOUN	名詞-普通名詞-サ変可能	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シセツ,施設,施設,施設,シセツ,,,シセツ,シセツ,施設
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3575,6 +3696,7 @@
 
 # newdoc id = dev-s124
 # sent_id = dev-s124
+# parallel_id = jagsd/dev124
 # text = マダガスカル・コモロ。
 1	マダガスカル	マダガスカル	PROPN	名詞-固有名詞-地名-国	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マダガスカル,マダガスカル,マダガスカル,マダガスカル,マダガスカル,,,マダガスカル,マダガスカルコモロ,マダガスカル・コモロ
 2	・	・	SYM	補助記号-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,マダガスカルコモロ,マダガスカル・コモロ
@@ -3583,6 +3705,7 @@
 
 # newdoc id = dev-s125
 # sent_id = dev-s125
+# parallel_id = jagsd/dev125
 # text = どこまでも自分しかいない、底なしの孤独。
 1	どこ	何処	PRON	代名詞	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ドコ,何処,どこ,どこ,ドコ,,,ドコ,ドコ,何処
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -3599,6 +3722,7 @@
 
 # newdoc id = dev-s126
 # sent_id = dev-s126
+# parallel_id = jagsd/dev126
 # text = 低公害車はそれほど多くはないが、ハイブリッドバスやCNGバスが導入されている。
 1	低	低	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テイ,低,低,低,テー,,,テイ,テイコウガイシャ,低公害車
 2	公害	公害	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウガイ,公害,公害,公害,コーガイ,,,コウガイ,テイコウガイシャ,低公害車
@@ -3626,6 +3750,7 @@
 
 # newdoc id = dev-s127
 # sent_id = dev-s127
+# parallel_id = jagsd/dev127
 # text = 8月31日の今日行ってきました。
 1	8	8	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ハチ,八,8,8,ハチ,,,ハチ,ハチガツ,8月
 2	月	月	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ガツ,月,月,月,ガツ,,,ガツ,ハチガツ,8月
@@ -3642,6 +3767,7 @@
 
 # newdoc id = dev-s128
 # sent_id = dev-s128
+# parallel_id = jagsd/dev128
 # text = 初めて行ったお店でしたが、価格も出来も満足しています。
 1	初めて	初めて	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ハジメテ,初めて,初めて,初めて,ハジメテ,,,ハジメテ,ハジメテ,初めて
 2	行っ	行く	VERB	動詞-非自立可能-五段-カ行	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-カ行|SpaceAfter=No|UnidicInfo=イク,行く,行っ,行く,イッ,,,イク,イク,行く
@@ -3665,6 +3791,7 @@
 
 # newdoc id = dev-s129
 # sent_id = dev-s129
+# parallel_id = jagsd/dev129
 # text = 超長距離戦に特化している分、自分から近い所には攻撃できない。
 1	超	超	NOUN	接頭辞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チョウ,超,超,超,チョー,,,チョウ,チョウチョウキョリセン,超長距離戦
 2	長	長	NOUN	接頭辞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チョウ,長,長,長,チョー,,,チョウ,チョウチョウキョリセン,超長距離戦
@@ -3690,6 +3817,7 @@
 
 # newdoc id = dev-s130
 # sent_id = dev-s130
+# parallel_id = jagsd/dev130
 # text = 1934年にトーキーに初出演。
 1	1934	1934	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九三四,1934,1934,イチキューサンヨ,,,イチキュウサンヨ,イチキュウサンヨンネン,1934年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチキュウサンヨンネン,1934年
@@ -3702,6 +3830,7 @@
 
 # newdoc id = dev-s131
 # sent_id = dev-s131
+# parallel_id = jagsd/dev131
 # text = 願いがあって来ている!
 1	願い	願い	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ネガイ,願い,願い,願い,ネガイ,,,ネガイ,ネガイ,願い
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3714,6 +3843,7 @@
 
 # newdoc id = dev-s132
 # sent_id = dev-s132
+# parallel_id = jagsd/dev132
 # text = 結婚11年目の夫浮気報道が持ち上がったとき、ヴィクトリアは彼を信じていたそうだが、寝も歯もないことを噂する世間に対し行き場のない怒りが湧き上がってきたのも事実だったそう。
 1	結婚	結婚	NOUN	名詞-普通名詞-サ変可能	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケッコン,結婚,結婚,結婚,ケッコン,,,ケッコン,ケッコン,結婚
 2	11	11	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一一,11,11,イチイチ,,,イチイチ,イチイチネンメ,11年目
@@ -3771,6 +3901,7 @@
 
 # newdoc id = dev-s133
 # sent_id = dev-s133
+# parallel_id = jagsd/dev133
 # text = まずは,1996年の教団本部移転が隆法氏による“霊言”に振り回されたという“ドタバタ劇”のお話。
 1	まず	先ず	ADV	副詞	_	30	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=マズ,先ず,まず,まず,マズ,,,マズ,マズ,先ず
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3806,6 +3937,7 @@
 
 # newdoc id = dev-s134
 # sent_id = dev-s134
+# parallel_id = jagsd/dev134
 # text = 一方ポリュネイケスの子テルサンドロスは戦争に勝利した後、トロイア戦争に参加したが、ギリシア軍は間違ってミューシアに上陸し、テーレポス王と戦争になった。
 1	一方	一方	CCONJ	接続詞	_	37	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	ポリュネイケス	ポリュネイケス	PROPN	名詞-固有名詞-人名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ポリュネイケース,ポリュネイケース,ポリュネイケス,ポリュネイケス,ポリュネーケス,,,ポリュネイケス,ポリュネイケス,ポリュネイケス
@@ -3849,6 +3981,7 @@
 
 # newdoc id = dev-s135
 # sent_id = dev-s135
+# parallel_id = jagsd/dev135
 # text = 現在は主に飼育下繁殖個体が流通する。
 1	現在	現在	NOUN	名詞-普通名詞-副詞可能	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3864,6 +3997,7 @@
 
 # newdoc id = dev-s136
 # sent_id = dev-s136
+# parallel_id = jagsd/dev136
 # text = 靴屋の父は、マックスが5歳の時に家族を捨て、マックスはパンや新聞の配達で家計を助けた。
 1	靴屋	靴屋	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クツヤ,靴屋,靴屋,靴屋,クツヤ,,,クツヤ,クツヤ,靴屋
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3897,6 +4031,7 @@
 
 # newdoc id = dev-s137
 # sent_id = dev-s137
+# parallel_id = jagsd/dev137
 # text = 全員起立して迎える。
 1	全員	全員	ADV	名詞-普通名詞-副詞可能	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ゼンイン,全員,全員,全員,ゼンイン,,,ゼンイン,ゼンイン,全員
 2	起立	起立	VERB	名詞-普通名詞-サ変可能	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=キリツ,起立,起立,起立,キリツ,,,キリツ,キリツスル,起立する
@@ -3907,6 +4042,7 @@
 
 # newdoc id = dev-s138
 # sent_id = dev-s138
+# parallel_id = jagsd/dev138
 # text = 大学で学生に教えていた経験からか人当たりも柔らかく実直な人物である。
 1	大学	大学	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダイガク,大学,大学,大学,ダイガク,,,ダイガク,ダイガク,大学
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3931,6 +4067,7 @@
 
 # newdoc id = dev-s139
 # sent_id = dev-s139
+# parallel_id = jagsd/dev139
 # text = 今日はランチにお刺身が食べたかったので、前々から気になっていたこちらにお邪魔しました。
 1	今日	今日	NOUN	名詞-普通名詞-副詞可能	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウ,今日,今日,今日,キョー,,,キョウ,キョウ,今日
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3964,6 +4101,7 @@
 
 # newdoc id = dev-s140
 # sent_id = dev-s140
+# parallel_id = jagsd/dev140
 # text = 微塵の良さもない!
 1	微塵	微塵	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ミジン,微塵,微塵,微塵,ミジン,,,ミジン,ミジン,微塵
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3975,6 +4113,7 @@
 
 # newdoc id = dev-s141
 # sent_id = dev-s141
+# parallel_id = jagsd/dev141
 # text = 説明も丁寧で分かりやすく、対応もとっても良かったです。
 1	説明	説明	NOUN	名詞-普通名詞-サ変可能	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セツメイ,説明,説明,説明,セツメー,,,セツメイ,セツメイ,説明
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -3993,6 +4132,7 @@
 
 # newdoc id = dev-s142
 # sent_id = dev-s142
+# parallel_id = jagsd/dev142
 # text = そこに当事者意識が生まれ,社会が実際に動いていく。
 1	そこ	其処	PRON	代名詞	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ソコ,其処,そこ,そこ,ソコ,,,ソコ,ソコ,其処
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4013,6 +4153,7 @@
 
 # newdoc id = dev-s143
 # sent_id = dev-s143
+# parallel_id = jagsd/dev143
 # text = 場所は多少わかりづらいんですけど、感じのいいところでした
 1	場所	場所	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バショ,場所,場所,場所,バショ,,,バショ,バショ,場所
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4032,6 +4173,7 @@
 
 # newdoc id = dev-s144
 # sent_id = dev-s144
+# parallel_id = jagsd/dev144
 # text = 駅から遠く、お酒を楽しむには不便なリッチなのが最大のネックですが、ドライバーを一人連れてでも行きたいお店です☆
 1	駅	駅	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エキ,駅,駅,駅,エキ,,,エキ,エキ,駅
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -4071,6 +4213,7 @@
 
 # newdoc id = dev-s145
 # sent_id = dev-s145
+# parallel_id = jagsd/dev145
 # text = そのため、三菱の携帯電話には、アニメっちゃのメール用画像素材やアプリがいくつか添付されている。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ため	為	NOUN	名詞-普通名詞-副詞可能	_	23	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タメ,為,ため,ため,タメ,,,タメ,タメ,為
@@ -4103,6 +4246,7 @@
 
 # newdoc id = dev-s146
 # sent_id = dev-s146
+# parallel_id = jagsd/dev146
 # text = 興行収入は32億円。
 1	興行	興行	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウギョウ,興行,興行,興行,コーギョー,,,コウギョウ,コウギョウシュウニュウ,興行収入
 2	収入	収入	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュウニュウ,収入,収入,収入,シューニュー,,,シュウニュウ,コウギョウシュウニュウ,興行収入
@@ -4114,6 +4258,7 @@
 
 # newdoc id = dev-s147
 # sent_id = dev-s147
+# parallel_id = jagsd/dev147
 # text = 多くの欠陥を抱えていたため生産数は100門と少なく、短い期間運用されたM7 プリーストやセクストンに置き換えられる形で一線から退いた。
 1	多く	多く	NOUN	名詞-普通名詞-副詞可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オオク,多く,多く,多く,オーク,,,オオク,オオク,多く
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4156,6 +4301,7 @@
 
 # newdoc id = dev-s148
 # sent_id = dev-s148
+# parallel_id = jagsd/dev148
 # text = 本気で譲ってほしいという人はいるのかしらん?
 1	本気	本気	ADJ	名詞-普通名詞-形状詞可能	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ホンキ,本気,本気,本気,ホンキ,,,ホンキ,ホンキ,本気
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -4173,6 +4319,7 @@
 
 # newdoc id = dev-s149
 # sent_id = dev-s149
+# parallel_id = jagsd/dev149
 # text = この会が“家系のおはなし”なる講演会を毎月公共施設で開いているとの情報が潜入取材を敢行した。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	会	会	NOUN	名詞-普通名詞-一般	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイ,会,会,会,カイ,,,カイ,カイ,会
@@ -4208,6 +4355,7 @@
 
 # newdoc id = dev-s150
 # sent_id = dev-s150
+# parallel_id = jagsd/dev150
 # text = 横浜市近辺で英会話を習いたいという人にはかなりいいのではないでしょうか?
 1	横浜	横浜	PROPN	名詞-固有名詞-地名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨコハマ,ヨコハマ,横浜,横浜,ヨコハマ,,,ヨコハマ,ヨコハマシキンペン,横浜市近辺
 2	市	市	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シ,市,市,市,シ,,,シ,ヨコハマシキンペン,横浜市近辺
@@ -4235,6 +4383,7 @@
 
 # newdoc id = dev-s151
 # sent_id = dev-s151
+# parallel_id = jagsd/dev151
 # text = 青雉に助けられた。
 1	青雉	青雉	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アオキジ,青雉,青雉,青雉,アオキジ,,,アオキジ,アオキジ,青雉
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4245,6 +4394,7 @@
 
 # newdoc id = dev-s152
 # sent_id = dev-s152
+# parallel_id = jagsd/dev152
 # text = 一方,淑徳大学に飯田氏を紹介したコンサルタントは,自団体のウェブサイトなどから飯田氏関連の記述を削除。
 1	一方	一方	CCONJ	接続詞	_	27	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -4277,6 +4427,7 @@
 
 # newdoc id = dev-s153
 # sent_id = dev-s153
+# parallel_id = jagsd/dev153
 # text = JTによると、廃作の募集は2004年に続いて2度目。
 1	JT	JT	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジェーティー,ＪＴ,JT,JT,ジェーティー,,,ジェーティー,ジェーティー,JT
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニヨルト,によると
@@ -4299,6 +4450,7 @@
 
 # newdoc id = dev-s154
 # sent_id = dev-s154
+# parallel_id = jagsd/dev154
 # text = 従来の同社製より素材の伸長率が35%向上し、着脱しやすくなったという。
 1	従来	従来	NOUN	名詞-普通名詞-副詞可能	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジュウライ,従来,従来,従来,ジューライ,,,ジュウライ,ジュウライ,従来
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4326,6 +4478,7 @@
 
 # newdoc id = dev-s155
 # sent_id = dev-s155
+# parallel_id = jagsd/dev155
 # text = 球状星団としてはまばらな方で、口径20cm程度の望遠鏡で周辺部は完全に分離でき、口径30cmでは中心部まで分離できる。
 1	球状	球状	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キュウジョウ,球状,球状,球状,キュージョー,,,キュウジョウ,キュウジョウセイダン,球状星団
 2	星団	星団	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイダン,星団,星団,星団,セーダン,,,セイダン,キュウジョウセイダン,球状星団
@@ -4368,6 +4521,7 @@
 
 # newdoc id = dev-s156
 # sent_id = dev-s156
+# parallel_id = jagsd/dev156
 # text = 窓側の席で若い女性が信者から入会を強く勧められている様子が確認できた。
 1	窓側	窓側	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マドガワ,窓側,窓側,窓側,マドガワ,,,マドガワ,マドガワ,窓側
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4394,6 +4548,7 @@
 
 # newdoc id = dev-s157
 # sent_id = dev-s157
+# parallel_id = jagsd/dev157
 # text = 山田が新作小説を発表しなくなってから、忍法帖シリーズに比べて正当に評価されていたとは言い難い作品群の再評価が始まった。
 1	山田	山田	PROPN	名詞-固有名詞-人名-姓	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=ヤマダ,ヤマダ,山田,山田,ヤマダ,,,ヤマダ,ヤマダ,山田
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4437,6 +4592,7 @@
 
 # newdoc id = dev-s158
 # sent_id = dev-s158
+# parallel_id = jagsd/dev158
 # text = その呼びかけに共感した淡井真紀、田中リタ、高原零、板倉あやのが秘密のアジトに集結した。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	呼びかけ	呼び掛け	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨビカケ,呼び掛け,呼びかけ,呼びかけ,ヨビカケ,,,ヨビカケ,ヨビカケ,呼び掛け
@@ -4467,6 +4623,7 @@
 
 # newdoc id = dev-s159
 # sent_id = dev-s159
+# parallel_id = jagsd/dev159
 # text = 下記に主な代表作を記述する。
 1	下記	下記	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カキ,下記,下記,下記,カキ,,,カキ,カキ,下記
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4480,6 +4637,7 @@
 
 # newdoc id = dev-s160
 # sent_id = dev-s160
+# parallel_id = jagsd/dev160
 # text = 憑いている“虫”は巨大ムカデ。
 1	憑い	付く	VERB	動詞-非自立可能-五段-カ行	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-カ行|SpaceAfter=No|UnidicInfo=ツク,付く,憑い,憑く,ツイ,,,ツク,ツク,付く
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助動詞-上一段-ア行|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テイル,ている
@@ -4494,6 +4652,7 @@
 
 # newdoc id = dev-s161
 # sent_id = dev-s161
+# parallel_id = jagsd/dev161
 # text = 現役時のポジションはゴールキーパー。
 1	現役	現役	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲンエキ,現役,現役,現役,ゲンエキ,,,ゲンエキ,ゲンエキジ,現役時
 2	時	時	NOUN	名詞-普通名詞-助数詞可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジ,時,時,時,ジ,,,ジ,ゲンエキジ,現役時
@@ -4506,6 +4665,7 @@
 
 # newdoc id = dev-s162
 # sent_id = dev-s162
+# parallel_id = jagsd/dev162
 # text = この時代から、日本列島に人類が住んだ遺跡や遺物が多く発見されている。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	時代	時代	NOUN	名詞-普通名詞-一般	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジダイ,時代,時代,時代,ジダイ,,,ジダイ,ジダイ,時代
@@ -4532,6 +4692,7 @@
 
 # newdoc id = dev-s163
 # sent_id = dev-s163
+# parallel_id = jagsd/dev163
 # text = 高橋由美子さんは創刊した1990年から登場。
 1	高橋	高橋	PROPN	名詞-固有名詞-人名-姓	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=タカハシ,タカハシ,高橋,高橋,タカハシ,,,タカハシ,タカハシユミコサン,高橋由美子さん
 2	由美子	由美子	PROPN	名詞-固有名詞-人名-名	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ユミコ,ユミコ,由美子,由美子,ユミコ,,,ユミコ,タカハシユミコサン,高橋由美子さん
@@ -4548,6 +4709,7 @@
 
 # newdoc id = dev-s164
 # sent_id = dev-s164
+# parallel_id = jagsd/dev164
 # text = クイズを行う場所や形式の関係上、早押しテーブルを設置することが困難な場合は、早押しボタンのボックスを挑戦者の手に持たせてクイズを行った。
 1	クイズ	クイズ	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クイズ,クイズ,クイズ,クイズ,クイズ,,,クイズ,クイズ,クイズ
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4592,6 +4754,7 @@
 
 # newdoc id = dev-s165
 # sent_id = dev-s165
+# parallel_id = jagsd/dev165
 # text = 一方、8市町以外で放射線量が高い場所が見つかった場合も、面積が広い場合には「国との協議で検討」し、局所的なら「補助金などの対象外」との認識が示された。
 1	一方	一方	CCONJ	接続詞	_	49	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4648,6 +4811,7 @@
 
 # newdoc id = dev-s167
 # sent_id = dev-s167
+# parallel_id = jagsd/dev167
 # text = 先日はありがとうございました。部下はヘビーナイトとバッティ、ブルームハッター、トライデントナイト。
 1	先日	先日	NOUN	名詞-普通名詞-副詞可能	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センジツ,先日,先日,先日,センジツ,,,センジツ,センジツ,先日
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4672,6 +4836,7 @@
 
 # newdoc id = dev-s168
 # sent_id = dev-s168
+# parallel_id = jagsd/dev168
 # text = レジにて受け取る「プリペイド番号通知票」のQRコードより携帯サイトにログイン。
 1	レジ	レジ	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=レジ,レジ,レジ,レジ,レジ,,,レジ,レジ,レジ
 2	にて	にて	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニテ,にて,にて,にて,ニテ,,,ニテ,ニテ,にて
@@ -4695,6 +4860,7 @@
 
 # newdoc id = dev-s169
 # sent_id = dev-s169
+# parallel_id = jagsd/dev169
 # text = 通信教育で挫折したので資格までとれるのか心配でしたが、無事合格し、仕事も決まりました!
 1	通信	通信	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ツウシン,通信,通信,通信,ツーシン,,,ツウシン,ツウシンキョウイク,通信教育
 2	教育	教育	NOUN	名詞-普通名詞-サ変可能	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウイク,教育,教育,教育,キョーイク,,,キョウイク,ツウシンキョウイク,通信教育
@@ -4727,6 +4893,7 @@
 
 # newdoc id = dev-s170
 # sent_id = dev-s170
+# parallel_id = jagsd/dev170
 # text = 試読もできます!
 1	試読	試読	NOUN	名詞-普通名詞-サ変可能	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シドク,試読,試読,試読,シドク,,,シドク,シドク,試読
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -4736,6 +4903,7 @@
 
 # newdoc id = dev-s171
 # sent_id = dev-s171
+# parallel_id = jagsd/dev171
 # text = 南アフリカで開かれるサッカーのワールドカップに合わせて、旅行会社では日本代表の試合を観戦するツアーを販売していますが、現地の治安が悪いことなどを理由に参加を見送るサポーターも多く、開幕まであと6日に迫った今もツアーが売れ残る状況が続いています。
 1	南アフリカ	南アフリカ	PROPN	名詞-固有名詞-地名-国	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=ミナミアフリカ,南アフリカ,南アフリカ,南アフリカ,ミナミアフリカ,,,ミナミアフリカ,ミナミアフリカ,南アフリカ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -4809,6 +4977,7 @@
 
 # newdoc id = dev-s172
 # sent_id = dev-s172
+# parallel_id = jagsd/dev172
 # text = 一方、BOφWY、JUDY AND MARYなど人気バンドが解散していくなかで、こうしたバンドのファンが新たにコピーバンドを結成するケースも目立つように各地で活動を継続している。
 1	一方	一方	CCONJ	接続詞	_	42	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4859,6 +5028,7 @@
 
 # newdoc id = dev-s173
 # sent_id = dev-s173
+# parallel_id = jagsd/dev173
 # text = 診察をしながらささっと診察データを書き込んでいるようなので、患者と患者の待ち時間は少ないように思います。
 1	診察	診察	NOUN	名詞-普通名詞-サ変可能	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンサツ,診察,診察,診察,シンサツ,,,シンサツ,シンサツ,診察
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4893,6 +5063,7 @@
 
 # newdoc id = dev-s174
 # sent_id = dev-s174
+# parallel_id = jagsd/dev174
 # text = 10年W杯南アフリカ大会後の昨夏も獲得に動いたAマドリードが、ここに来て再び獲得に乗り出していることが判明。
 1	10	10	NUM	名詞-数詞	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ジュウ,十,10,10,ジュー,,,ジュウ,ジュウネン,10年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	7	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ジュウネン,10年
@@ -4929,6 +5100,7 @@
 
 # newdoc id = dev-s175
 # sent_id = dev-s175
+# parallel_id = jagsd/dev175
 # text = この選考について労働基準法違反に抵触する疑いがあるとして、厚生労働省が調査を開始した。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	選考	選考	NOUN	名詞-普通名詞-サ変可能	_	15	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センコウ,選考,選考,選考,センコー,,,センコウ,センコウ,選考
@@ -4962,6 +5134,7 @@
 
 # newdoc id = dev-s176
 # sent_id = dev-s176
+# parallel_id = jagsd/dev176
 # text = 広大で対象となる亡者も多いため政令指定地獄となっているが、亡者は地表に落ちるまで2000年落下し続けるため実際に服役する数はそれほどでもなく、仕事自体はまだヒマな方である。
 1	広大	広大	ADJ	形状詞-一般	_	8	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=コウダイ,広大,広大,広大,コーダイ,,,コウダイ,コウダイ,広大
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -5018,6 +5191,7 @@
 
 # newdoc id = dev-s177
 # sent_id = dev-s177
+# parallel_id = jagsd/dev177
 # text = 内容は、下表の通り。
 1	内容	内容	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナイヨウ,内容,内容,内容,ナイヨー,,,ナイヨウ,ナイヨウ,内容
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5029,6 +5203,7 @@
 
 # newdoc id = dev-s178
 # sent_id = dev-s178
+# parallel_id = jagsd/dev178
 # text = 冷戦中だったため、西側の状況は国家にとっても国民にとっても指標であったが、東ドイツは西ドイツの経済成長の速度に、端から追いついておらず、このことは国民を怒らせた。
 1	冷戦	冷戦	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=レイセン,冷戦,冷戦,冷戦,レーセン,,,レイセン,レイセンチュウ,冷戦中
 2	中	中	NOUN	接尾辞-名詞的-副詞可能	_	5	acl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チュウ,中,中,中,チュー,,,チュウ,レイセンチュウ,冷戦中
@@ -5085,6 +5260,7 @@
 
 # newdoc id = dev-s179
 # sent_id = dev-s179
+# parallel_id = jagsd/dev179
 # text = ジェボムの俳優および歌手活動など、芸能活動全般を支援する見通しだ。
 1	ジェボム	ジェボム	PROPN	名詞-固有名詞-人名-一般	_	11	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ジェボム,ジェボム,ジェボム,ジェボム,ジェボム,,,ジェボム,ジェボム,ジェボム
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5106,6 +5282,7 @@
 
 # newdoc id = dev-s180
 # sent_id = dev-s180
+# parallel_id = jagsd/dev180
 # text = 美声ではないのに演歌の心というか魂の叫びというか、とにかくこちらにズシーンと響いてくるような歌唱力の持ち主だった。
 1	美声	美声	NOUN	名詞-普通名詞-一般	_	33	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ビセイ,美声,美声,美声,ビセー,,,ビセイ,ビセイ,美声
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助動詞-形容詞|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,デハナイ,ではない
@@ -5146,6 +5323,7 @@
 
 # newdoc id = dev-s181
 # sent_id = dev-s181
+# parallel_id = jagsd/dev181
 # text = ネバダとは「雪に覆われた」という意味であり、地域の雪を冠した山々を指すものだった。
 1	ネバダ	ネバダ	PROPN	名詞-固有名詞-地名-一般	_	13	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ネバダ,ネバダ,ネバダ,ネバダ,ネバダ,,,ネバダ,ネバダ,ネバダ
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -5179,6 +5357,7 @@
 
 # newdoc id = dev-s182
 # sent_id = dev-s182
+# parallel_id = jagsd/dev182
 # text = ホテル・コルテシア東京で挙式予定の客。
 1	ホテル	ホテル	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホテル,ホテル,ホテル,ホテル,ホテル,,,ホテル,ホテルコルテシアトウキョウ,ホテル・コルテシア東京
 2	・	・	SYM	補助記号-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,ホテルコルテシアトウキョウ,ホテル・コルテシア東京
@@ -5193,6 +5372,7 @@
 
 # newdoc id = dev-s183
 # sent_id = dev-s183
+# parallel_id = jagsd/dev183
 # text = サクラも動員されていたようだ。
 1	サクラ	桜	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サクラ,桜,サクラ,サクラ,サクラ,,,サクラ,サクラ,桜
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -5208,6 +5388,7 @@
 
 # newdoc id = dev-s184
 # sent_id = dev-s184
+# parallel_id = jagsd/dev184
 # text = せまい待合室の受付で、症状を口頭で言わされました。
 1	せまい	狭い	ADJ	形容詞-一般-形容詞	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=セマイ,狭い,せまい,せまい,セマイ,,,セマイ,セマイ,狭い
 2	待合	待ち合い	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マチアイ,待ち合い,待合,待合,マチアイ,,,マチアイ,マチアイシツ,待ち合い室
@@ -5228,6 +5409,7 @@
 
 # newdoc id = dev-s185
 # sent_id = dev-s185
+# parallel_id = jagsd/dev185
 # text = KGBの文書には、死因は「動脈硬化に伴う循環器疾患」と記録されている。
 1	KGB	KGB	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケージービー,ＫＧＢ,KGB,KGB,ケージービー,,,ケージービー,ケージービー,KGB
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5256,6 +5438,7 @@
 
 # newdoc id = dev-s186
 # sent_id = dev-s186
+# parallel_id = jagsd/dev186
 # text = FBIがポールセンを追い始めた時、彼は逃亡者として地下に潜っていた。
 1	FBI	FBI	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エフビーアイ,ＦＢＩ,FBI,FBI,エフビーアイ,,,エフビーアイ,エフビーアイ,FBI
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5283,6 +5466,7 @@
 
 # newdoc id = dev-s187
 # sent_id = dev-s187
+# parallel_id = jagsd/dev187
 # text = 再装填は人力である。
 1	再	再	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サイ,再,再,再,サイ,,,サイ,サイソウテン,再装填
 2	装填	装填	NOUN	名詞-普通名詞-サ変可能	_	4	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ソウテン,装填,装填,装填,ソーテン,,,ソウテン,サイソウテン,再装填
@@ -5294,6 +5478,7 @@
 
 # newdoc id = dev-s188
 # sent_id = dev-s188
+# parallel_id = jagsd/dev188
 # text = スタッフの方やお店の雰囲気良かったです。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフ,スタッフ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5310,6 +5495,7 @@
 
 # newdoc id = dev-s189
 # sent_id = dev-s189
+# parallel_id = jagsd/dev189
 # text = 現代でもイランやパキスタンではこのナスタアリーク体が使われているようです。
 1	現代	現代	NOUN	名詞-普通名詞-副詞可能	_	13	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲンダイ,現代,現代,現代,ゲンダイ,,,ゲンダイ,ゲンダイ,現代
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -5333,6 +5519,7 @@
 
 # newdoc id = dev-s190
 # sent_id = dev-s190
+# parallel_id = jagsd/dev190
 # text = 市政委員会が火薬は植民地の財産であり、イギリス国王のものではないと主張して、火薬の返還を要求した。
 1	市政	市政	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シセイ,市政,市政,市政,シセー,,,シセイ,シセイイインカイ,市政委員会
 2	委員	委員	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イイン,委員,委員,委員,イイン,,,イイン,シセイイインカイ,市政委員会
@@ -5370,6 +5557,7 @@
 
 # newdoc id = dev-s191
 # sent_id = dev-s191
+# parallel_id = jagsd/dev191
 # text = 薬の事全然わかりませんでしたが、丁寧に案内してもらい、買いたい物が買えました。
 1	薬	薬	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クスリ,薬,薬,薬,クスリ,,,クスリ,クスリ,薬
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5400,6 +5588,7 @@
 
 # newdoc id = dev-s192
 # sent_id = dev-s192
+# parallel_id = jagsd/dev192
 # text = だから,日本が軍備をしちゃいかんというんだったら,もう自衛隊なんてやめてまえ。
 1	だ	だ	CCONJ	助動詞-助動詞-ダ	_	22	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダカラ,だから
 2	から	から	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,ダカラ,だから
@@ -5429,6 +5618,7 @@
 
 # newdoc id = dev-s193
 # sent_id = dev-s193
+# parallel_id = jagsd/dev193
 # text = なお、町田修は「店長くん」として同社のキャラクターとなっている。
 1	なお	猶	CCONJ	接続詞	_	17	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5453,6 +5643,7 @@
 
 # newdoc id = dev-s194
 # sent_id = dev-s194
+# parallel_id = jagsd/dev194
 # text = NBAのコーチの中には試合中に大きな声や身振り手振りで選手に指示をする者も多いが、スコットは腕組みをしたまま寡黙に試合の行方を見守る。
 1	NBA	NBA	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=エヌビーエー,ＮＢＡ,NBA,NBA,エヌビーエー,,,エヌビーエー,エヌビーエー,NBA
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5498,6 +5689,7 @@
 
 # newdoc id = dev-s195
 # sent_id = dev-s195
+# parallel_id = jagsd/dev195
 # text = 設立は1965年。
 1	設立	設立	NOUN	名詞-普通名詞-サ変可能	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セツリツ,設立,設立,設立,セツリツ,,,セツリツ,セツリツ,設立
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5507,6 +5699,7 @@
 
 # newdoc id = dev-s196
 # sent_id = dev-s196
+# parallel_id = jagsd/dev196
 # text = 彼女の存在は、ゲーテのほかシラー、ヘルダーなど同時代のヴァイマルの文人たちに大きな影響を与えた。
 1	彼女	彼女	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=カノジョ,彼女,彼女,彼女,カノジョ,,,カノジョ,カノジョ,彼女
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5537,6 +5730,7 @@
 
 # newdoc id = dev-s197
 # sent_id = dev-s197
+# parallel_id = jagsd/dev197
 # text = 2500円のコースで、私はお肉・相方がお魚を選びました。
 1	2500	2500	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二五ゼロゼロ,2500,2500,ニゴゼロゼロ,,,ニゴゼロゼロ,ニゴゼロゼロエン,2500円
 2	円	円	NOUN	名詞-普通名詞-助数詞可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=エン,円,円,円,エン,,,エン,ニゴゼロゼロエン,2500円
@@ -5561,6 +5755,7 @@
 
 # newdoc id = dev-s198
 # sent_id = dev-s198
+# parallel_id = jagsd/dev198
 # text = そのため人間界での舞台は里帰りのみとなる。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ため	為	NOUN	名詞-普通名詞-副詞可能	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タメ,為,ため,ため,タメ,,,タメ,タメ,為
@@ -5578,12 +5773,14 @@
 
 # newdoc id = dev-s199
 # sent_id = dev-s199
+# parallel_id = jagsd/dev199
 # text = ヴァイオリニスト。
 1	ヴァイオリニスト	バイオリニスト	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バイオリニスト,バイオリニスト,ヴァイオリニスト,ヴァイオリニスト,バイオリニスト,,,バイオリニスト,バイオリニスト,バイオリニスト
 2	。	。	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-句点|UnidicInfo=,。,。,。,,,,,,。
 
 # newdoc id = dev-s200
 # sent_id = dev-s200
+# parallel_id = jagsd/dev200
 # text = 他の軍団員と違ってシュララ軍団から足を洗いたいと思っており、登場目的はケロロ小隊に捕らえられた兄を救うことであった。
 1	他	他	NOUN	名詞-普通名詞-副詞可能	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホカ,他,他,他,ホカ,,,ホカ,ホカ,他
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5624,6 +5821,7 @@
 
 # newdoc id = dev-s201
 # sent_id = dev-s201
+# parallel_id = jagsd/dev201
 # text = *1902年-ドイツ選手権がスタート。
 1	*	*	PUNCT	補助記号-一般	_	9	punct	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=補助記号-一般|SpaceAfter=No|UnidicInfo=,＊,*,*,,,,,,＊
 2	1902	1902	NUM	名詞-数詞	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九ゼロ二,1902,1902,イチキューゼロニ,,,イチキュウゼロニ,イチキュウゼロニネン,1902年
@@ -5638,6 +5836,7 @@
 
 # newdoc id = dev-s202
 # sent_id = dev-s202
+# parallel_id = jagsd/dev202
 # text = 週に3回は行ってます。
 1	週	週	NOUN	名詞-普通名詞-助数詞可能	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュウ,週,週,週,シュー,,,シュウ,シュウ,週
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -5651,6 +5850,7 @@
 
 # newdoc id = dev-s203
 # sent_id = dev-s203
+# parallel_id = jagsd/dev203
 # text = ノンビリキング十三世の部屋。
 1	ノンビリ	のんびり	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ノンビリ,のんびり,ノンビリ,ノンビリ,ノンビリ,,,ノンビリ,ノンビリキング,のんびりキング
 2	キング	キング	NOUN	名詞-普通名詞-一般	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キング,キング,キング,キング,キング,,,キング,ノンビリキング,のんびりキング
@@ -5663,6 +5863,7 @@
 
 # newdoc id = dev-s204
 # sent_id = dev-s204
+# parallel_id = jagsd/dev204
 # text = 現在、その名称はアトレティコの下部組織の名前として残っている。
 1	現在	現在	ADV	名詞-普通名詞-副詞可能	_	15	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5685,6 +5886,7 @@
 
 # newdoc id = dev-s205
 # sent_id = dev-s205
+# parallel_id = jagsd/dev205
 # text = 特に六代目尾上梅幸を相方とした演目は名高い。
 1	特に	特に	ADV	副詞	_	14	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=トクニ,特に,特に,特に,トクニ,,,トクニ,トクニ,特に
 2	六	六	NUM	名詞-数詞	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ロク,六,六,六,ロク,,,ロク,ロクダイメオノエバイコウ,六代目尾上梅幸
@@ -5704,6 +5906,7 @@
 
 # newdoc id = dev-s206
 # sent_id = dev-s206
+# parallel_id = jagsd/dev206
 # text = 東日本大震災をきっかけに東京電力福島第1原発の危機的な状況が続いている。
 1	東	東	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒガシ,東,東,東,ヒガシ,,,ヒガシ,ヒガシニホンダイシンサイ,東日本大震災
 2	日本	日本	PROPN	名詞-固有名詞-地名-国	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニホン,,,ニホン,ヒガシニホンダイシンサイ,東日本大震災
@@ -5731,6 +5934,7 @@
 
 # newdoc id = dev-s207
 # sent_id = dev-s207
+# parallel_id = jagsd/dev207
 # text = 何故か教員用の大型の三角定規を持っている事が多い。
 1	何故	何故	ADV	副詞	_	11	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ナゼ,何故,何故,何故,ナゼ,,,ナゼ,ナゼ,何故
 2	か	か	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=カ,か,か,か,カ,,,カ,カ,か
@@ -5752,6 +5956,7 @@
 
 # newdoc id = dev-s208
 # sent_id = dev-s208
+# parallel_id = jagsd/dev208
 # text = 最初の2ヶ月間,自社のサービスを理解するためって事でユーザーサポートを担当しました。
 1	最初	最初	NOUN	名詞-普通名詞-副詞可能	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サイショ,最初,最初,最初,サイショ,,,サイショ,サイショ,最初
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5780,6 +5985,7 @@
 
 # newdoc id = dev-s209
 # sent_id = dev-s209
+# parallel_id = jagsd/dev209
 # text = 2011年1月でレギュラー放送が終了し、今後は特番前の特別番組として放送される。
 1	2011	2011	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロ一一,2011,2011,ニゼロイチイチ,,,ニゼロイチイチ,ニゼロイチイチネン,2011年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロイチイチネン,2011年
@@ -5809,6 +6015,7 @@
 
 # newdoc id = dev-s210
 # sent_id = dev-s210
+# parallel_id = jagsd/dev210
 # text = その後、他の音楽番組を担当し、TBSを退職。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-副詞可能	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -5828,6 +6035,7 @@
 
 # newdoc id = dev-s211
 # sent_id = dev-s211
+# parallel_id = jagsd/dev211
 # text = これが無い場合、作業者は死に至る致命傷を負う場合もある。
 1	これ	此れ	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5851,6 +6059,7 @@
 
 # newdoc id = dev-s212
 # sent_id = dev-s212
+# parallel_id = jagsd/dev212
 # text = SMEが、生産性の向上と革新を進め、経済の牽引役となることを目的としている。
 1	SME	SME	NOUN	名詞-普通名詞-一般	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エスエムイー,ＳＭＥ,SME,SME,エスエムイー,,,エスエムイー,エスエムイー,SME
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5881,6 +6090,7 @@
 
 # newdoc id = dev-s213
 # sent_id = dev-s213
+# parallel_id = jagsd/dev213
 # text = 当時3回連続でオーダーミス。
 1	当時	当時	NOUN	名詞-普通名詞-副詞可能	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウジ,当時,当時,当時,トージ,,,トウジ,トウジ,当時
 2	3	3	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サン,三,3,3,サン,,,サン,サンカイレンゾク,3回連続
@@ -5893,6 +6103,7 @@
 
 # newdoc id = dev-s214
 # sent_id = dev-s214
+# parallel_id = jagsd/dev214
 # text = また、香辛料を輸入するため、さかんにマカッサル王国とも交易をおこなった。
 1	また	又	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5917,6 +6128,7 @@
 
 # newdoc id = dev-s215
 # sent_id = dev-s215
+# parallel_id = jagsd/dev215
 # text = 彼等の遺体は数日間晒されて、最終的にノグ山に埋葬された。
 1	彼	彼	PRON	代名詞	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=カレ,彼,彼,彼,カレ,,,カレ,カレラ,彼等
 2	等	等	NOUN	接尾辞-名詞的-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ラ,等,等,等,ラ,,,ラ,カレラ,彼等
@@ -5943,6 +6155,7 @@
 
 # newdoc id = dev-s216
 # sent_id = dev-s216
+# parallel_id = jagsd/dev216
 # text = 伊勢丹時代にカリスマバイヤーとして名を馳せ、その後、様々な再建、ブランド創成、売り場プロデュースなどを手がけてきた藤巻幸夫氏。
 1	伊勢丹	伊勢丹	PROPN	名詞-固有名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イセタン,伊勢丹,伊勢丹,伊勢丹,イセタン,,,イセタン,イセタンジダイ,伊勢丹時代
 2	時代	時代	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジダイ,時代,時代,時代,ジダイ,,,ジダイ,イセタンジダイ,伊勢丹時代
@@ -5981,6 +6194,7 @@
 
 # newdoc id = dev-s217
 # sent_id = dev-s217
+# parallel_id = jagsd/dev217
 # text = ちなみにここには載せきれませんでしたが,ラッパを吹いている天使はコンクリート製。
 1	ちなみ	因み	CCONJ	名詞-普通名詞-一般	_	22	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=チナミ,因み,ちなみ,ちなみ,チナミ,,,チナミ,チナミニ,因みに
 2	に	に	ADP	助詞-格助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,チナミニ,因みに
@@ -6008,6 +6222,7 @@
 
 # newdoc id = dev-s218
 # sent_id = dev-s218
+# parallel_id = jagsd/dev218
 # text = 佐脇有紀裁判長は,吉田被告について“本件に果たした役割は主導的で積極的”とし,元警察官として“犯行の情状も悪い”としながらも,被告が素直に犯行を認め二度と犯罪を起こさないと反省していることや弁護士会に100万円を寄付したことなどを総合考慮し執行猶予付きの判決となったと述べた。
 1	佐脇	佐脇	PROPN	名詞-固有名詞-人名-姓	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=サワキ,サワキ,佐脇,佐脇,サワキ,,,サワキ,サワキユキサイバンチョウ,佐脇有紀裁判長
 2	有紀	有紀	PROPN	名詞-固有名詞-人名-名	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ユキ,ユキ,有紀,有紀,ユキ,,,ユキ,サワキユキサイバンチョウ,佐脇有紀裁判長
@@ -6107,6 +6322,7 @@
 
 # newdoc id = dev-s219
 # sent_id = dev-s219
+# parallel_id = jagsd/dev219
 # text = 髪は薄茶色で毛先が渦巻きカールになった髪型をしている。
 1	髪	髪	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カミ,髪,髪,髪,カミ,,,カミ,カミ,髪
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6129,6 +6345,7 @@
 
 # newdoc id = dev-s220
 # sent_id = dev-s220
+# parallel_id = jagsd/dev220
 # text = 2月17日にグアムアプラ港に寄港し、グアム到着後は燃料と物資を補給して2月17日に出港。
 1	2	2	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二,2,2,ニ,,,ニ,ニガツ,2月
 2	月	月	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ガツ,月,月,月,ガツ,,,ガツ,ニガツ,2月
@@ -6163,6 +6380,7 @@
 
 # newdoc id = dev-s221
 # sent_id = dev-s221
+# parallel_id = jagsd/dev221
 # text = 表題曲『港の五番町』の作詞は阿久悠、作曲は彩木雅夫である。
 1	表題	表題	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒョウダイ,表題,表題,表題,ヒョーダイ,,,ヒョウダイ,ヒョウダイキョク,表題曲
 2	曲	曲	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョク,曲,曲,曲,キョク,,,キョク,ヒョウダイキョク,表題曲
@@ -6187,6 +6405,7 @@
 
 # newdoc id = dev-s222
 # sent_id = dev-s222
+# parallel_id = jagsd/dev222
 # text = 安くてうまいです。
 1	安く	安い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=ヤスイ,安い,安く,安い,ヤスク,,,ヤスイ,ヤスイ,安い
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-接続助詞|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -6196,6 +6415,7 @@
 
 # newdoc id = dev-s223
 # sent_id = dev-s223
+# parallel_id = jagsd/dev223
 # text = マイクスタンドは彼の背後から伸び、頭上を通って眼前に降ろす可動式のものを使用、必要に応じて都度、ドラム・テクがマイクスタンドを操作している。
 1	マイク	マイク	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マイク,マイク,マイク,マイク,マイク,,,マイク,マイクスタンド,マイクスタンド
 2	スタンド	スタンド	NOUN	名詞-普通名詞-一般	_	22	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スタンド,スタンド,スタンド,スタンド,スタンド,,,スタンド,マイクスタンド,マイクスタンド
@@ -6241,6 +6461,7 @@
 
 # newdoc id = dev-s224
 # sent_id = dev-s224
+# parallel_id = jagsd/dev224
 # text = 宗教法人格の取り消し云々は,結局のところ,その宗教の持つ教義そのものについて,善悪の判断を加えることになるだろう。
 1	宗教	宗教	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュウキョウ,宗教,宗教,宗教,シューキョー,,,シュウキョウ,シュウキョウホウジンカク,宗教法人格
 2	法人	法人	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホウジン,法人,法人,法人,ホージン,,,ホウジン,シュウキョウホウジンカク,宗教法人格
@@ -6278,6 +6499,7 @@
 
 # newdoc id = dev-s225
 # sent_id = dev-s225
+# parallel_id = jagsd/dev225
 # text = 同氏はドジャースで2度ワールドシリーズを制覇。
 1	同氏	同氏	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウシ,同氏,同氏,同氏,ドーシ,,,ドウシ,ドウシ,同氏
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6293,6 +6515,7 @@
 
 # newdoc id = dev-s226
 # sent_id = dev-s226
+# parallel_id = jagsd/dev226
 # text = 男性による、番組名・曲名等の簡単な英語ナビゲートがあったが、WEB上で情報が一切公開されておらず、氏名等は一切不明である。
 1	男性	男性	NOUN	名詞-普通名詞-一般	_	14	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダンセイ,男性,男性,男性,ダンセー,,,ダンセイ,ダンセイ,男性
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニヨル,による
@@ -6337,6 +6560,7 @@
 
 # newdoc id = dev-s227
 # sent_id = dev-s227
+# parallel_id = jagsd/dev227
 # text = そして回答の最後に,週刊誌の編集部に対して,こんな一文。
 1	そして	そして	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	回答	回答	NOUN	名詞-普通名詞-サ変可能	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイトウ,回答,回答,回答,カイトー,,,カイトウ,カイトウ,回答
@@ -6360,6 +6584,7 @@
 
 # newdoc id = dev-s228
 # sent_id = dev-s228
+# parallel_id = jagsd/dev228
 # text = 日本では江戸時代から昭和にかけて、主に農家以外で飼い猫の首輪の喉の部分に鈴を一つつけることが行われてきた。
 1	日本	日本	PROPN	名詞-固有名詞-地名-国	_	31	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニッポン,,,ニッポン,ニッポン,日本
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -6400,6 +6625,7 @@
 
 # newdoc id = dev-s229
 # sent_id = dev-s229
+# parallel_id = jagsd/dev229
 # text = 既に高麗の太祖の時期から、貴族は王権に対する強力な挑戦者だった。
 1	既に	既に	ADV	副詞	_	17	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=スデニ,既に,既に,既に,スデニ,,,スデニ,スデニ,既に
 2	高麗	高麗	PROPN	名詞-固有名詞-地名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=コウライ,コウライ,高麗,高麗,コーライ,,,コウライ,コウライ,高麗
@@ -6424,6 +6650,7 @@
 
 # newdoc id = dev-s230
 # sent_id = dev-s230
+# parallel_id = jagsd/dev230
 # text = 1800年代は旧制高等学校の医学部薬学科として設置されたが、1900年代には旧制高等学校から医学専門学校が分離された、また私立の薬学専門学校も設置された。
 1	1800	1800	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イチ,一八ゼロゼロ,1800,1800,イチハチゼロゼロ,,,イチハチゼロゼロ,イチハチゼロゼロネンダイ,1800年代
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチハチゼロゼロネンダイ,1800年代
@@ -6479,6 +6706,7 @@
 
 # newdoc id = dev-s231
 # sent_id = dev-s231
+# parallel_id = jagsd/dev231
 # text = 店員の教育が残念な店。
 1	店員	店員	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テンイン,店員,店員,店員,テンイン,,,テンイン,テンイン,店員
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6491,6 +6719,7 @@
 
 # newdoc id = dev-s232
 # sent_id = dev-s232
+# parallel_id = jagsd/dev232
 # text = 昭和が最も輝いていた昭和30年代中盤以降の日用雑貨、菓子のパッケージ、ビール瓶や飲料水の缶、そしてポスターにパネルなど。
 1	昭和	昭和	PROPN	名詞-固有名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ショウワ,昭和,昭和,昭和,ショーワ,,,ショウワ,ショウワ,昭和
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6530,6 +6759,7 @@
 
 # newdoc id = dev-s233
 # sent_id = dev-s233
+# parallel_id = jagsd/dev233
 # text = 後藤の事が大好きになってしまった様々な作戦を使い嫌われようという企画。
 1	後藤	後藤	PROPN	名詞-固有名詞-人名-姓	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=ゴトウ,ゴトウ,後藤,後藤,ゴトー,,,ゴトウ,ゴトウ,後藤
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6555,6 +6785,7 @@
 
 # newdoc id = dev-s234
 # sent_id = dev-s234
+# parallel_id = jagsd/dev234
 # text = 大きさが全く違う海老とか調理側は何故平気なんだろ。
 1	大き	大きい	ADJ	形容詞-一般-形容詞	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オオキイ,大きい,大き,大きい,オーキ,,,オオキイ,オオキサ,大きさ
 2	さ	さ	PART	接尾辞-名詞的-一般	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サ,さ,さ,さ,サ,,,サ,オオキサ,大きさ
@@ -6576,6 +6807,7 @@
 
 # newdoc id = dev-s235
 # sent_id = dev-s235
+# parallel_id = jagsd/dev235
 # text = でも、リニューアルしたゲストハウス風のロビー?
 1	で	で	CCONJ	助詞-格助詞	_	10	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デモ,でも
 2	も	も	ADP	助詞-係助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,デモ,でも
@@ -6591,6 +6823,7 @@
 
 # newdoc id = dev-s236
 # sent_id = dev-s236
+# parallel_id = jagsd/dev236
 # text = 2008年に入り、楽天がイーバンク銀行と資本提携を行うこととなり、イーバンク銀行が新規に発行する第三者割当の優先株を楽天が引き受けることになり、同年9月30日付で社長を含む一部経営陣も楽天の役員から起用された。
 1	2008	2008	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ八,2008,2008,ニゼロゼロハチ,,,ニゼロゼロハチ,ニゼロゼロハチネン,2008年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロハチネン,2008年
@@ -6660,6 +6893,7 @@
 
 # newdoc id = dev-s237
 # sent_id = dev-s237
+# parallel_id = jagsd/dev237
 # text = 導入にあたっては10回線以上299回線以下が条件であり2回線から、および300回線以上も導入できるソフトバンクモバイルオフィスと比べると条件を問われる。
 1	導入	導入	NOUN	名詞-普通名詞-サ変可能	_	36	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウニュウ,導入,導入,導入,ドーニュー,,,ドウニュウ,ドウニュウ,導入
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニアタッテ,にあたって
@@ -6702,6 +6936,7 @@
 
 # newdoc id = dev-s238
 # sent_id = dev-s238
+# parallel_id = jagsd/dev238
 # text = 2007年からは、加藤ピンの仕事が多い。
 1	2007	2007	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ七,2007,2007,ニゼロゼロシチ,,,ニゼロゼロシチ,ニゼロゼロシチネン,2007年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	11	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロシチネン,2007年
@@ -6718,6 +6953,7 @@
 
 # newdoc id = dev-s239
 # sent_id = dev-s239
+# parallel_id = jagsd/dev239
 # text = 突如、臆病な人格となって弱体化してしまう負の時間と呼ばれる一定の時間があるのが、この種族の最大の弱点。
 1	突如	突如	ADV	副詞	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=トツジョ,突如,突如,突如,トツジョ,,,トツジョ,トツジョ,突如
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6756,6 +6992,7 @@
 
 # newdoc id = dev-s240
 # sent_id = dev-s240
+# parallel_id = jagsd/dev240
 # text = 昨年の12月30日、日中は病棟当番だった鈴木は、夕方当直勤務に入った。
 1	昨年	昨年	NOUN	名詞-普通名詞-副詞可能	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サクネン,昨年,昨年,昨年,サクネン,,,サクネン,サクネン,昨年
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6783,6 +7020,7 @@
 
 # newdoc id = dev-s241
 # sent_id = dev-s241
+# parallel_id = jagsd/dev241
 # text = “創価学会”のラベルの記事には,しばしば“創価学会に人気の霊園”という広告が表示されています。
 1	“	“	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	創価	創価	PROPN	名詞-固有名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ソウカ,創価,創価,創価,ソーカ,,,ソウカ,ソウカガッカイ,創価学会
@@ -6818,6 +7056,7 @@
 
 # newdoc id = dev-s242
 # sent_id = dev-s242
+# parallel_id = jagsd/dev242
 # text = それでも小原は1963年4月に持っていた金は事件と無関係と言い張ったが、平塚らは「これだけ材料を突きつけられてまだ逃れられると思っているのか」と小原を追い詰め、それからほどなくして小原は金が吉展ちゃん事件と関係のあるものだと供述した。
 1	それ	其れ	CCONJ	代名詞	_	22	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレデモ,其れでも
 2	で	で	ADP	助詞-格助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,ソレデモ,其れでも
@@ -6896,6 +7135,7 @@
 
 # newdoc id = dev-s243
 # sent_id = dev-s243
+# parallel_id = jagsd/dev243
 # text = 同基金では、ひとり親家庭の就業支援も新規に実施。
 1	同	同	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウ,同,同,同,ドー,,,ドウ,ドウキキン,同基金
 2	基金	基金	NOUN	名詞-普通名詞-一般	_	14	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キキン,基金,基金,基金,キキン,,,キキン,ドウキキン,同基金
@@ -6915,6 +7155,7 @@
 
 # newdoc id = dev-s244
 # sent_id = dev-s244
+# parallel_id = jagsd/dev244
 # text = でも、まずはハーフドリアではなく1人前のドリアをお試し下さい。
 1	で	で	CCONJ	助詞-格助詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デモ,でも
 2	も	も	ADP	助詞-係助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,デモ,でも
@@ -6939,6 +7180,7 @@
 
 # newdoc id = dev-s245
 # sent_id = dev-s245
+# parallel_id = jagsd/dev245
 # text = 出場国は6カ国。
 1	出場	出場	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュツジョウ,出場,出場,出場,シュツジョー,,,シュツジョウ,シュツジョウコク,出場国
 2	国	国	NOUN	接尾辞-名詞的-一般	_	5	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コク,国,国,国,コク,,,コク,シュツジョウコク,出場国
@@ -6949,6 +7191,7 @@
 
 # newdoc id = dev-s246
 # sent_id = dev-s246
+# parallel_id = jagsd/dev246
 # text = 文字を取り扱う範囲は10FFFFまでである。
 1	文字	文字	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=モジ,文字,文字,文字,モジ,,,モジ,モジ,文字
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -6967,6 +7210,7 @@
 
 # newdoc id = dev-s247
 # sent_id = dev-s247
+# parallel_id = jagsd/dev247
 # text = 2010年11月28日のDDT・後楽園ホール大会で首を負傷し「後縦靱帯骨化症」と診断される。
 1	2010	2010	NUM	名詞-数詞	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロ一ゼロ,2010,2010,ニゼロイチゼロ,,,ニゼロイチゼロ,ニゼロイチゼロネン,2010年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロイチゼロネン,2010年
@@ -7000,6 +7244,7 @@
 
 # newdoc id = dev-s248
 # sent_id = dev-s248
+# parallel_id = jagsd/dev248
 # text = 郡内には自然湖が無いが、多くの河川がある。
 1	郡内	郡内	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=グンナイ,郡内,郡内,郡内,グンナイ,,,グンナイ,グンナイ,郡内
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7019,6 +7264,7 @@
 
 # newdoc id = dev-s249
 # sent_id = dev-s249
+# parallel_id = jagsd/dev249
 # text = クラブの経営を支える大きな柱の一つである入場料収入も、2005年をピークに年々減少しております。
 1	クラブ	クラブ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クラブ,クラブ,クラブ,クラブ,クラブ,,,クラブ,クラブ,クラブ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7052,6 +7298,7 @@
 
 # newdoc id = dev-s250
 # sent_id = dev-s250
+# parallel_id = jagsd/dev250
 # text = 福音書はヘンリー8世の命令による修道院の解散時にダラム大聖堂から持ち出され、17世紀初頭に英国議会の書記官、トーマス・ウォーカーからロバート・コットンの手に渡り、18世紀には大英博物館に納められ、更にそこからロンドンの大英図書館に移された。
 1	福音	福音	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フクイン,福音,福音,福音,フクイン,,,フクイン,フクインショ,福音書
 2	書	書	NOUN	接尾辞-名詞的-一般	_	21	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショ,書,書,書,ショ,,,ショ,フクインショ,福音書
@@ -7125,6 +7372,7 @@
 
 # newdoc id = dev-s251
 # sent_id = dev-s251
+# parallel_id = jagsd/dev251
 # text = 2011年の日本トンデモ本大賞は,ニコニコ生放送の投票だけでなく,会場の新宿ロフトプラスワンでの投票も影響するので,これだけで大川隆法氏の受賞が決まったわけではありません。
 1	2011	2011	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロ一一,2011,2011,ニゼロイチイチ,,,ニゼロイチイチ,ニゼロイチイチネン,2011年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	7	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロイチイチネン,2011年
@@ -7180,6 +7428,7 @@
 
 # newdoc id = dev-s252
 # sent_id = dev-s252
+# parallel_id = jagsd/dev252
 # text = 横浜横須賀道路と新湘南バイパスは、終日5割引。
 1	横浜	横浜	PROPN	名詞-固有名詞-地名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨコハマ,ヨコハマ,横浜,横浜,ヨコハマ,,,ヨコハマ,ヨコハマヨコスカドウロ,横浜横須賀道路
 2	横須賀	横須賀	PROPN	名詞-固有名詞-地名-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨコスカ,ヨコスカ,横須賀,横須賀,ヨコスカ,,,ヨコスカ,ヨコハマヨコスカドウロ,横浜横須賀道路
@@ -7197,6 +7446,7 @@
 
 # newdoc id = dev-s253
 # sent_id = dev-s253
+# parallel_id = jagsd/dev253
 # text = 月のお社から脱走したシモーヌという名の女精霊使いを探している。
 1	月	月	NOUN	名詞-普通名詞-助数詞可能	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ツキ,月,月,月,ツキ,,,ツキ,ニクヅキ,肉月
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7222,6 +7472,7 @@
 
 # newdoc id = dev-s254
 # sent_id = dev-s254
+# parallel_id = jagsd/dev254
 # text = すべて私のせいでとんでもないご迷惑ばかりおかけし,この期に及んでも足をひっぱるばかりで,もう本当にお詫びの言葉もありません。
 1	すべて	全て	ADV	名詞-普通名詞-副詞可能	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=スベテ,全て,すべて,すべて,スベテ,,,スベテ,スベテ,全て
 2	私	私	PRON	代名詞	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
@@ -7264,6 +7515,7 @@
 
 # newdoc id = dev-s255
 # sent_id = dev-s255
+# parallel_id = jagsd/dev255
 # text = 現在は女優となり、最近はドラマで母親役が多い。
 1	現在	現在	NOUN	名詞-普通名詞-副詞可能	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7283,6 +7535,7 @@
 
 # newdoc id = dev-s256
 # sent_id = dev-s256
+# parallel_id = jagsd/dev256
 # text = 東京らしいシンプルな銭湯。
 1	東京	東京	PROPN	名詞-固有名詞-地名-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=トウキョウ,トウキョウ,東京,東京,トーキョー,,,トウキョウ,トウキョウラシイ,東京らしい
 2	らしい	らしい	AUX	接尾辞-形容詞的-形容詞	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=ラシイ,らしい,らしい,らしい,ラシー,,,ラシイ,トウキョウラシイ,東京らしい
@@ -7293,6 +7546,7 @@
 
 # newdoc id = dev-s257
 # sent_id = dev-s257
+# parallel_id = jagsd/dev257
 # text = ベンが処刑され、ウィラが地元のアイスクリーム屋で働いて生計を立てるようになった或る日、クリーサップの街にハリーが突然あらわれた。
 1	ベン	ベン	PROPN	名詞-固有名詞-人名-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ベン,ベン,ベン,ベン,ベン,,,ベン,ベン,ベン
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7333,6 +7587,7 @@
 
 # newdoc id = dev-s258
 # sent_id = dev-s258
+# parallel_id = jagsd/dev258
 # text = 徳島市の東部に位置し、吉野川下流デルタ地帯の一角をなす。
 1	徳島	徳島	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=トクシマ,トクシマ,徳島,徳島,トクシマ,,,トクシマ,トクシマシ,徳島市
 2	市	市	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=シ,市,市,市,シ,,,シ,トクシマシ,徳島市
@@ -7354,6 +7609,7 @@
 
 # newdoc id = dev-s259
 # sent_id = dev-s259
+# parallel_id = jagsd/dev259
 # text = 地元の農家の方が作った野菜のコーナーが好きです。
 1	地元	地元	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジモト,地元,地元,地元,ジモト,,,ジモト,ジモト,地元
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7373,6 +7629,7 @@
 
 # newdoc id = dev-s260
 # sent_id = dev-s260
+# parallel_id = jagsd/dev260
 # text = ※GI昇格後の年度に限定。
 1	※	※	SYM	補助記号-一般	_	8	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=補助記号-一般|SpaceAfter=No|UnidicInfo=,※,※,※,,,,,,※
 2	GI	GI	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジーアイ,ＧＩ,GI,GI,ジーアイ,,,ジーアイ,ジーアイショウカクゴ,GI昇格後
@@ -7386,6 +7643,7 @@
 
 # newdoc id = dev-s261
 # sent_id = dev-s261
+# parallel_id = jagsd/dev261
 # text = 第3次以降の平成23年度補正予算案にNEMIC整備のための調査費計上を目指している。
 1	第	第	NOUN	接頭辞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダイ,第,第,第,ダイ,,,ダイ,ダイサンジイコウ,第3次以降
 2	3	3	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サン,三,3,3,サン,,,サン,ダイサンジイコウ,第3次以降
@@ -7415,6 +7673,7 @@
 
 # newdoc id = dev-s262
 # sent_id = dev-s262
+# parallel_id = jagsd/dev262
 # text = 「ありがとうございます」とお礼を言い、笑顔で味わっていた。
 1	「	「	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	ありがとう	有り難い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=アリガタイ,有り難い,ありがとう,ありがたい,アリガトー,,,アリガタイ,アリガタイ,有り難い
@@ -7437,6 +7696,7 @@
 
 # newdoc id = dev-s263
 # sent_id = dev-s263
+# parallel_id = jagsd/dev263
 # text = 主な項目に関する最終案の内容は以下のとおり。
 1	主な	主な	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=オモナ,主な,主な,主な,オモナ,,,オモナ,オモナ,主な
 2	項目	項目	NOUN	名詞-普通名詞-一般	_	8	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウモク,項目,項目,項目,コーモク,,,コウモク,コウモク,項目
@@ -7454,6 +7714,7 @@
 
 # newdoc id = dev-s264
 # sent_id = dev-s264
+# parallel_id = jagsd/dev264
 # text = 先を歩いていたミニスカートの女性がNKプリントの前で自動車にはね飛ばされる。
 1	先	先	NOUN	名詞-普通名詞-副詞可能	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サキ,先,先,先,サキ,,,サキ,サキ,先
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7479,6 +7740,7 @@
 
 # newdoc id = dev-s265
 # sent_id = dev-s265
+# parallel_id = jagsd/dev265
 # text = 『ミューミューニャーニャー』はNHKの幼児向け番組『おかあさんといっしょ』の人形劇のコーナー。
 1	『	『	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
 2	ミューミュー	みゅーみゅー	ADV	副詞	_	3	advmod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ミューミュー,みゅーみゅー,ミューミュー,ミューミュー,ミューミュー,,,ミューミュー,ミューミューニャアニャア,みゅーみゅーにゃあにゃあ
@@ -7506,6 +7768,7 @@
 
 # newdoc id = dev-s266
 # sent_id = dev-s266
+# parallel_id = jagsd/dev266
 # text = 同年はリザーブチームで6回プレーした。
 1	同年	同年	NOUN	名詞-普通名詞-副詞可能	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウネン,同年,同年,同年,ドーネン,,,ドウネン,ドウネン,同年
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7521,6 +7784,7 @@
 
 # newdoc id = dev-s267
 # sent_id = dev-s267
+# parallel_id = jagsd/dev267
 # text = 女性教会員が立候補した松戸市議選でも,足立教会の信者が大量動員されていた。
 1	女性	女性	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョセイ,女性,女性,女性,ジョセー,,,ジョセイ,ジョセイキョウカイイン,女性教会員
 2	教会	教会	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウカイ,教会,教会,教会,キョーカイ,,,キョウカイ,ジョセイキョウカイイン,女性教会員
@@ -7552,6 +7816,7 @@
 
 # newdoc id = dev-s268
 # sent_id = dev-s268
+# parallel_id = jagsd/dev268
 # text = 2000年のシドニーオリンピックではいずれも予選敗退だった。
 1	2000	2000	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロゼロ,2000,2000,ニゼロゼロゼロ,,,ニゼロゼロゼロ,ニゼロゼロゼロネン,2000年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロゼロネン,2000年
@@ -7570,6 +7835,7 @@
 
 # newdoc id = dev-s269
 # sent_id = dev-s269
+# parallel_id = jagsd/dev269
 # text = 東京の中でも新宿といういい立地でありながら、お料理の味やドレスの素敵さを考えるととても良心的な結婚式場という感じがしました。
 1	東京	東京	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=トウキョウ,トウキョウ,東京,東京,トーキョー,,,トウキョウ,トウキョウ,東京
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7614,6 +7880,7 @@
 
 # newdoc id = dev-s270
 # sent_id = dev-s270
+# parallel_id = jagsd/dev270
 # text = 陳敦仁:統振株式有限会社理事長。
 1	陳	陳	PROPN	名詞-固有名詞-人名-姓	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=チン,チン,陳,陳,チン,,,チン,チントンジン,陳敦仁
 2	敦仁	敦仁	PROPN	名詞-固有名詞-人名-名	_	9	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=トンジン,トンジン,敦仁,敦仁,トンジン,,,トンジン,チントンジン,陳敦仁
@@ -7628,6 +7895,7 @@
 
 # newdoc id = dev-s271
 # sent_id = dev-s271
+# parallel_id = jagsd/dev271
 # text = 水曜日と金曜日に図書室で貸し出しの作業をしている。
 1	水曜	水曜	NOUN	名詞-普通名詞-副詞可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スイヨウ,水曜,水曜,水曜,スイヨー,,,スイヨウ,スイヨウビ,水曜日
 2	日	日	NOUN	名詞-普通名詞-副詞可能	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ビ,,,ヒ,スイヨウビ,水曜日
@@ -7649,6 +7917,7 @@
 
 # newdoc id = dev-s272
 # sent_id = dev-s272
+# parallel_id = jagsd/dev272
 # text = 本作の隠しキャラクターの1人。
 1	本作	本作	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホンサク,本作,本作,本作,ホンサク,,,ホンサク,ホンサク,本作
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7660,6 +7929,7 @@
 
 # newdoc id = dev-s273
 # sent_id = dev-s273
+# parallel_id = jagsd/dev273
 # text = セキュリティの点でも、安心して住めるよう、オートロックシステムをはじめ、防犯カメラ、ディンプルキー・鎌デッド錠、エレベータには防犯モニタが設置されています。
 1	セキュリティ	セキュリティー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セキュリティー,セキュリティー,セキュリティ,セキュリティ,セキュリティ,,,セキュリティ,セキュリティ,セキュリティ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7705,6 +7975,7 @@
 
 # newdoc id = dev-s274
 # sent_id = dev-s274
+# parallel_id = jagsd/dev274
 # text = 超新星の所属事務所,株式会社maroo企画です。
 1	超	超	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チョウ,超,超,超,チョー,,,チョウ,チョウシンセイ,超新星
 2	新星	新星	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンセイ,新星,新星,新星,シンセー,,,シンセイ,チョウシンセイ,超新星
@@ -7722,6 +7993,7 @@
 
 # newdoc id = dev-s275
 # sent_id = dev-s275
+# parallel_id = jagsd/dev275
 # text = 2012年現在、外車だけでもランボルギーニ・ミウラP400SV、フェラーリ・F512M、ベンツ、BMWの4台を保有し、中でもランボルギーニ・ミウラは1971年生産の車体で41年が経過した時点でも走行可能と、極めて良好なコンディションである。
 1	2012	2012	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロ一二,2012,2012,ニゼロイチニ,,,ニゼロイチニ,ニゼロイチニネンゲンザイ,2012年現在
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロイチニネンゲンザイ,2012年現在
@@ -7790,6 +8062,7 @@
 
 # newdoc id = dev-s276
 # sent_id = dev-s276
+# parallel_id = jagsd/dev276
 # text = 今後とも超新星を応援いただきますよう,よろしくお願いいたします。
 1	今後	今後	ADV	名詞-普通名詞-副詞可能	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=コンゴ,今後,今後,今後,コンゴ,,,コンゴ,コンゴトモ,今後共
 2	とも	共	NOUN	接尾辞-名詞的-副詞可能	_	6	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=トモ,共,とも,とも,トモ,,,トモ,コンゴトモ,今後共
@@ -7810,6 +8083,7 @@
 
 # newdoc id = dev-s277
 # sent_id = dev-s277
+# parallel_id = jagsd/dev277
 # text = 山頂までの距離は、4.8kmである。
 1	山頂	山頂	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サンチョウ,山頂,山頂,山頂,サンチョー,,,サンチョウ,サンチョウ,山頂
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -7827,6 +8101,7 @@
 
 # newdoc id = dev-s278
 # sent_id = dev-s278
+# parallel_id = jagsd/dev278
 # text = さっさと潰れろ!
 1	さっさと	さっさと	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=サッサト,さっさと,さっさと,さっさと,サッサト,,,サッサト,サッサト,さっさと
 2	潰れろ	潰れる	VERB	動詞-一般-下一段-ラ行	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=動詞-一般-下一段-ラ行|SpaceAfter=No|UnidicInfo=ツブレル,潰れる,潰れろ,潰れる,ツブレロ,,,ツブレル,ツブレル,潰れる
@@ -7834,6 +8109,7 @@
 
 # newdoc id = dev-s279
 # sent_id = dev-s279
+# parallel_id = jagsd/dev279
 # text = 台湾守備混成第2旅団長を経て、日露戦争に歩兵第1旅団長として出征し、南山の戦いに参戦。
 1	台湾	台湾	PROPN	名詞-固有名詞-地名-一般	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タイワン,タイワン,台湾,台湾,タイワン,,,タイワン,タイワンシュビコンセイダイニリョダンチョウ,台湾守備混成第2旅団長
 2	守備	守備	NOUN	名詞-普通名詞-サ変可能	_	7	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュビ,守備,守備,守備,シュビ,,,シュビ,タイワンシュビコンセイダイニリョダンチョウ,台湾守備混成第2旅団長
@@ -7869,6 +8145,7 @@
 
 # newdoc id = dev-s280
 # sent_id = dev-s280
+# parallel_id = jagsd/dev280
 # text = 主な内容は本格的な古典演奏から和楽器を使ったロックやポップスの紹介と、DJによる大学生活や舞台でのエピソードトーク。
 1	主な	主な	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=オモナ,主な,主な,主な,オモナ,,,オモナ,オモナ,主な
 2	内容	内容	NOUN	名詞-普通名詞-一般	_	32	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナイヨウ,内容,内容,内容,ナイヨー,,,ナイヨウ,ナイヨウ,内容
@@ -7906,6 +8183,7 @@
 
 # newdoc id = dev-s281
 # sent_id = dev-s281
+# parallel_id = jagsd/dev281
 # text = 連合は緒戦の勢いを失い、双方の首都をめぐりバージニア州で行われていた東部戦線は膠着状態に陥る一方、南軍の西部戦線にほころびが生じた。
 1	連合	連合	NOUN	名詞-普通名詞-サ変可能	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=レンゴウ,連合,連合,連合,レンゴー,,,レンゴウ,レンゴウ,連合
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7950,6 +8228,7 @@
 
 # newdoc id = dev-s282
 # sent_id = dev-s282
+# parallel_id = jagsd/dev282
 # text = とりわけバグダードでは神学教授のガザーリーなどが活躍した。
 1	とりわけ	取り分け	ADV	副詞	_	11	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=トリワケ,取り分け,とりわけ,とりわけ,トリワケ,,,トリワケ,トリワケ,取り分け
 2	バグダード	バグダード	PROPN	名詞-固有名詞-地名-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=バグダッド,バグダッド,バグダード,バグダード,バグダード,,,バグダード,バグダード,バグダード
@@ -7968,6 +8247,7 @@
 
 # newdoc id = dev-s283
 # sent_id = dev-s283
+# parallel_id = jagsd/dev283
 # text = これにあたる語としてはملكがあり、字義としては「今まさに持っている」という意味合いになる。
 1	これ	此れ	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8003,6 +8283,7 @@
 
 # newdoc id = dev-s284
 # sent_id = dev-s284
+# parallel_id = jagsd/dev284
 # text = 先日,坂本弁護士失踪事件直後のテレビ放送のVTRや波野村での反対集会の映像を観る機会があった。
 1	先日	先日	ADV	名詞-普通名詞-副詞可能	_	27	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=センジツ,先日,先日,先日,センジツ,,,センジツ,センジツ,先日
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -8036,6 +8317,7 @@
 
 # newdoc id = dev-s285
 # sent_id = dev-s285
+# parallel_id = jagsd/dev285
 # text = 一部を抜粋します。
 1	一部	一部	NOUN	名詞-普通名詞-副詞可能	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イチブ,一部,一部,一部,イチブ,,,イチブ,イチブ,一部
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8046,6 +8328,7 @@
 
 # newdoc id = dev-s286
 # sent_id = dev-s286
+# parallel_id = jagsd/dev286
 # text = 調子に乗りやすく、危険な獣相手にピンチに陥ることも。
 1	調子	調子	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チョウシ,調子,調子,調子,チョーシ,,,チョウシ,チョウシ,調子
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8066,6 +8349,7 @@
 
 # newdoc id = dev-s287
 # sent_id = dev-s287
+# parallel_id = jagsd/dev287
 # text = 白馬に入る入り口のスキー場でもあってとても奇麗でやることいっぱい!
 1	白馬	白馬	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ハクバ,ハクバ,白馬,白馬,ハクバ,,,ハクバ,ハクバ,白馬
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8088,6 +8372,7 @@
 
 # newdoc id = dev-s288
 # sent_id = dev-s288
+# parallel_id = jagsd/dev288
 # text = 普段は成績が悪く遅刻を繰り返す問題児で、第1話では喧嘩で相手を骨折させて自宅謹慎まで受けていたが、その反面、正義感が強く仲間からの信頼も厚い。
 1	普段	普段	NOUN	名詞-普通名詞-副詞可能	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フダン,普段,普段,普段,フダン,,,フダン,フダン,普段
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8140,6 +8425,7 @@
 
 # newdoc id = dev-s289
 # sent_id = dev-s289
+# parallel_id = jagsd/dev289
 # text = また、同ライブへ向け、両バンドのカップリング楽曲と映像を収録したCD&DVDパッケージ『Phoenix Rising』が10月12日にリリースされる。
 1	また	又	CCONJ	接続詞	_	33	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8180,6 +8466,7 @@
 
 # newdoc id = dev-s290
 # sent_id = dev-s290
+# parallel_id = jagsd/dev290
 # text = 出演者も特有の風と降りしきる雨に悩ませられた。
 1	出演	出演	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュツエン,出演,出演,出演,シュツエン,,,シュツエン,シュツエンシャ,出演者
 2	者	者	NOUN	接尾辞-名詞的-一般	_	11	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シャ,者,者,者,シャ,,,シャ,シュツエンシャ,出演者
@@ -8199,6 +8486,7 @@
 
 # newdoc id = dev-s291
 # sent_id = dev-s291
+# parallel_id = jagsd/dev291
 # text = コダールの完成型であるコダールiも『揺れるイントゥ・ザ・ブルー』でビルの倒壊に対してラムダ・ドライバを発動させオーバーヒートを起こしているが、検査の結果何の異常も見られなかったため、こちらはガウルンによるブラフと見られる。
 1	コダール	コダール	PROPN	名詞-固有名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=コダール,コダール,コダール,コダール,コダール,,,コダール,コダール,コダール
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8264,6 +8552,7 @@
 
 # newdoc id = dev-s292
 # sent_id = dev-s292
+# parallel_id = jagsd/dev292
 # text = 意識を取り戻した友作は階段から落ちた後、危篤状態だった時間と同じ57分間だけ他人の心の声が聞こえる能力を手に入れていた。
 1	意識	意識	NOUN	名詞-普通名詞-サ変可能	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イシキ,意識,意識,意識,イシキ,,,イシキ,イシキ,意識
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8306,6 +8595,7 @@
 
 # newdoc id = dev-s293
 # sent_id = dev-s293
+# parallel_id = jagsd/dev293
 # text = 全国霊感商法対策弁護士連絡会の渡辺博弁護士は2009年7月,統一日報の取材に“統一教会は民団や総連といった在日韓国人組織の活動にも入り込み,信者獲得を進めている”と語っている。
 1	全国	全国	NOUN	名詞-普通名詞-一般	_	8	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゼンコク,全国,全国,全国,ゼンコク,,,ゼンコク,ゼンコクレイカンショウホウタイサクベンゴシレンラクカイ,全国霊感商法対策弁護士連絡会
 2	霊感	霊感	NOUN	名詞-普通名詞-一般	_	8	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=レイカン,霊感,霊感,霊感,レーカン,,,レイカン,ゼンコクレイカンショウホウタイサクベンゴシレンラクカイ,全国霊感商法対策弁護士連絡会
@@ -8366,6 +8656,7 @@
 
 # newdoc id = dev-s294
 # sent_id = dev-s294
+# parallel_id = jagsd/dev294
 # text = 編成番号は2両・3両単位で付番され、識別記号「HE」を冠し「HE-104」のように表す。
 1	編成	編成	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヘンセイ,編成,編成,編成,ヘンセー,,,ヘンセイ,ヘンセイバンゴウ,編成番号
 2	番号	番号	NOUN	名詞-普通名詞-一般	_	32	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バンゴウ,番号,番号,番号,バンゴー,,,バンゴウ,ヘンセイバンゴウ,編成番号
@@ -8403,6 +8694,7 @@
 
 # newdoc id = dev-s295
 # sent_id = dev-s295
+# parallel_id = jagsd/dev295
 # text = 信者にとってはありがたい存在なのであろうが,正直カリスマ性は感じられなかった。
 1	信者	信者	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンジャ,信者,信者,信者,シンジャ,,,シンジャ,シンジャ,信者
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニトッテ,にとって
@@ -8429,6 +8721,7 @@
 
 # newdoc id = dev-s296
 # sent_id = dev-s296
+# parallel_id = jagsd/dev296
 # text = 単に「属人主義」という積極的属人主義を指す場合が多い。
 1	単に	単に	ADV	副詞	_	13	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=タンニ,単に,単に,単に,タンニ,,,タンニ,タンニ,単に
 2	「	「	PUNCT	補助記号-括弧開	_	4	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
@@ -8450,6 +8743,7 @@
 
 # newdoc id = dev-s297
 # sent_id = dev-s297
+# parallel_id = jagsd/dev297
 # text = この特別代表は、現在知られているサイトは日本や韓国の北朝鮮支持者が運営していると明らかにしたという。
 1	この	此の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	特別	特別	ADJ	形状詞-一般	_	3	amod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トクベツ,特別,特別,特別,トクベツ,,,トクベツ,トクベツダイヒョウ,特別代表
@@ -8486,6 +8780,7 @@
 
 # newdoc id = dev-s298
 # sent_id = dev-s298
+# parallel_id = jagsd/dev298
 # text = 幸福の科学の広報担当者によると,今回の広告掲載は“フライデー事件”以来,19年ぶりとのことです。
 1	幸福	幸福	NOUN	名詞-普通名詞-形状詞可能	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=コウフク,幸福,幸福,幸福,コーフク,,,コウフク,コウフクノカガク,幸福の科学
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,コウフクノカガク,幸福の科学
@@ -8520,6 +8815,7 @@
 
 # newdoc id = dev-s299
 # sent_id = dev-s299
+# parallel_id = jagsd/dev299
 # text = 統一教会広報に問い合わせた。
 1	統一	統一	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウイツ,統一,統一,統一,トーイツ,,,トウイツ,トウイツキョウカイコウホウ,統一教会広報
 2	教会	教会	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウカイ,教会,教会,教会,キョーカイ,,,キョウカイ,トウイツキョウカイコウホウ,統一教会広報
@@ -8531,6 +8827,7 @@
 
 # newdoc id = dev-s300
 # sent_id = dev-s300
+# parallel_id = jagsd/dev300
 # text = PRACTICEモードはステージ3で終了だが、クリア時にベルを50個以上保持していればステージ4以降に進める。
 1	PRACTICE	PRACTICE	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=プラクティス,プラクティス,PRACTICE,PRACTICE,プラクティス,,,プラクティス,プラクティスモード,PRACTICEモード
 2	モード	モード	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=モード,モード,モード,モード,モード,,,モード,プラクティスモード,PRACTICEモード
@@ -8564,6 +8861,7 @@
 
 # newdoc id = dev-s301
 # sent_id = dev-s301
+# parallel_id = jagsd/dev301
 # text = 主人公の隣のアパートに引っ越してきた幼稚園の先生。
 1	主人	主人	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュジン,主人,主人,主人,シュジン,,,シュジン,シュジンコウ,主人公
 2	公	公	NOUN	接尾辞-名詞的-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウ,公,公,公,コー,,,コウ,シュジンコウ,主人公
@@ -8584,6 +8882,7 @@
 
 # newdoc id = dev-s302
 # sent_id = dev-s302
+# parallel_id = jagsd/dev302
 # text = アンジェロの一人娘であるジェニファーは、命の危険から遠ざけるために、幼い頃に養女に出されていた。
 1	アンジェロ	アンジェロ	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=アンジェロ,アンジェロ,アンジェロ,アンジェロ,アンジェロ,,,アンジェロ,アンジェロ,アンジェロ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8615,6 +8914,7 @@
 
 # newdoc id = dev-s303
 # sent_id = dev-s303
+# parallel_id = jagsd/dev303
 # text = 桜井高校はランナー1.3塁から内野ゴロで先制します。
 1	桜井	桜井	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=サクライ,サクライ,桜井,桜井,サクライ,,,サクライ,サクライコウコウ,桜井高校
 2	高校	高校	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=コウコウ,高校,高校,高校,コーコー,,,コウコウ,サクライコウコウ,桜井高校
@@ -8635,6 +8935,7 @@
 
 # newdoc id = dev-s304
 # sent_id = dev-s304
+# parallel_id = jagsd/dev304
 # text = 5人以上だときついかもしれないけど、少人数の時にはまた使いたいです。
 1	5	5	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴ,五,5,5,ゴ,,,ゴ,ゴニンイジョウ,5人以上
 2	人	人	NOUN	接尾辞-名詞的-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニン,人,人,人,ニン,,,ニン,ゴニンイジョウ,5人以上
@@ -8662,6 +8963,7 @@
 
 # newdoc id = dev-s305
 # sent_id = dev-s305
+# parallel_id = jagsd/dev305
 # text = シーズン終了後球団社長のジョン・ショーは辞任し、12月22日にはジェイ・ジグムンドに代わってビリー・ディバニーがゼネラルマネージャーとなった。
 1	シーズン	シーズン	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=シーズン,シーズン,シーズン,シーズン,シーズン,,,シーズン,シーズンシュウリョウゴ,シーズン終了後
 2	終了	終了	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=シュウリョウ,終了,終了,終了,シューリョー,,,シュウリョウ,シーズンシュウリョウゴ,シーズン終了後
@@ -8701,6 +9003,7 @@
 
 # newdoc id = dev-s306
 # sent_id = dev-s306
+# parallel_id = jagsd/dev306
 # text = 1462年、アラゴン王フアン2世と、最初の妃であるナバラ女王ブランカ1世との間の王子カルラスが、ナバラ王位を巡って争うことになった。
 1	1462	1462	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一四六二,1462,1462,イチヨンロクニ,,,イチヨンロクニ,イチヨンロクニネン,1462年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	34	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチヨンロクニネン,1462年
@@ -8744,6 +9047,7 @@
 
 # newdoc id = dev-s307
 # sent_id = dev-s307
+# parallel_id = jagsd/dev307
 # text = 大部分が6車線で、品川埠頭の連絡道である。
 1	大	大	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダイ,大,大,大,ダイ,,,ダイ,ダイブブン,大部分
 2	部分	部分	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ブブン,部分,部分,部分,ブブン,,,ブブン,ダイブブン,大部分
@@ -8763,6 +9067,7 @@
 
 # newdoc id = dev-s308
 # sent_id = dev-s308
+# parallel_id = jagsd/dev308
 # text = 旅の途中で出会うモンスターを模した家具を、マイハウスに設置可能。
 1	旅	旅	NOUN	名詞-普通名詞-サ変可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タビ,旅,旅,旅,タビ,,,タビ,タビ,旅
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8785,6 +9090,7 @@
 
 # newdoc id = dev-s309
 # sent_id = dev-s309
+# parallel_id = jagsd/dev309
 # text = さらにその後、ビデオによる撮影が主流となるに従い、ビデオ機材を組み込んだ総合的なシステムとしてのスタジオが主流となった。
 1	さらに	更に	CCONJ	接続詞	_	33	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=サラニ,更に,さらに,さらに,サラニ,,,サラニ,サラニ,更に
 2	その	其の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
@@ -8824,6 +9130,7 @@
 
 # newdoc id = dev-s310
 # sent_id = dev-s310
+# parallel_id = jagsd/dev310
 # text = 外見は田舎の一般住宅のノリですが、津幡の店とは思えないクオリティーです。
 1	外見	外見	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ガイケン,外見,外見,外見,ガイケン,,,ガイケン,ガイケン,外見
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8849,6 +9156,7 @@
 
 # newdoc id = dev-s311
 # sent_id = dev-s311
+# parallel_id = jagsd/dev311
 # text = 九州大学大学院法学研究院准教授を経て、現在同教授。
 1	九州	九州	PROPN	名詞-固有名詞-地名-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=キュウシュウ,キュウシュウ,九州,九州,キューシュー,,,キュウシュウ,キュウシュウダイガクダイガクイン,九州大学大学院
 2	大学	大学	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ダイガク,大学,大学,大学,ダイガク,,,ダイガク,キュウシュウダイガクダイガクイン,九州大学大学院
@@ -8870,6 +9178,7 @@
 
 # newdoc id = dev-s312
 # sent_id = dev-s312
+# parallel_id = jagsd/dev312
 # text = 実に狡猾なやり口だ。
 1	実	実	NOUN	名詞-普通名詞-副詞可能	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジツ,実,実,実,ジツ,,,ジツ,ジツ,実
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8881,6 +9190,7 @@
 
 # newdoc id = dev-s313
 # sent_id = dev-s313
+# parallel_id = jagsd/dev313
 # text = 車両手配上の都合からホンダ車以外の他社の車両を使用する際には、車両の前部・後部に番組タイトルロゴ付きの板を被せていた。
 1	車両	車両	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シャリョウ,車両,車両,車両,シャリョー,,,シャリョウ,シャリョウテハイジョウ,車両手配上
 2	手配	手配	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テハイ,手配,手配,手配,テハイ,,,テハイ,シャリョウテハイジョウ,車両手配上
@@ -8923,6 +9233,7 @@
 
 # newdoc id = dev-s314
 # sent_id = dev-s314
+# parallel_id = jagsd/dev314
 # text = 日本向けには脱脂粉乳、雑穀類を食料として送った。
 1	日本	日本	PROPN	名詞-固有名詞-地名-国	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニッポン,,,ニッポン,ニッポンムケ,日本向け
 2	向け	向け	NOUN	接尾辞-名詞的-一般	_	15	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ムケ,向け,向け,向け,ムケ,,,ムケ,ニッポンムケ,日本向け
@@ -8944,6 +9255,7 @@
 
 # newdoc id = dev-s315
 # sent_id = dev-s315
+# parallel_id = jagsd/dev315
 # text = 今後は高校野球などアマチュア野球の公式戦の他、プロ野球の二軍公式戦を誘致する方針である。
 1	今後	今後	NOUN	名詞-普通名詞-副詞可能	_	24	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コンゴ,今後,今後,今後,コンゴ,,,コンゴ,コンゴ,今後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8975,6 +9287,7 @@
 
 # newdoc id = dev-s316
 # sent_id = dev-s316
+# parallel_id = jagsd/dev316
 # text = そもそも港市支配者は、外来商人と領域内の住民とを仲立ちすることこそが自らの拠って立つ基盤であった。
 1	そもそも	抑	ADV	名詞-普通名詞-副詞可能	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ソモソモ,抑,そもそも,そもそも,ソモソモ,,,ソモソモ,ソモソモ,抑
 2	港市	港市	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウシ,港市,港市,港市,コーシ,,,コウシ,コウシシハイシャ,港市支配者
@@ -9009,6 +9322,7 @@
 
 # newdoc id = dev-s317
 # sent_id = dev-s317
+# parallel_id = jagsd/dev317
 # text = そして現場へ着くと不思議な光に包まれる。
 1	そして	そして	CCONJ	接続詞	_	10	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	現場	現場	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲンバ,現場,現場,現場,ゲンバ,,,ゲンバ,ゲンバ,現場
@@ -9025,6 +9339,7 @@
 
 # newdoc id = dev-s318
 # sent_id = dev-s318
+# parallel_id = jagsd/dev318
 # text = 私はよく通ってますが、親切丁寧に対応してくださって安心です。
 1	私	私	PRON	代名詞	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9048,6 +9363,7 @@
 
 # newdoc id = dev-s319
 # sent_id = dev-s319
+# parallel_id = jagsd/dev319
 # text = 大学在学中に、最初の文学賞を受賞する。
 1	大学	大学	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダイガク,大学,大学,大学,ダイガク,,,ダイガク,ダイガクザイガクチュウ,大学在学中
 2	在学	在学	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ザイガク,在学,在学,在学,ザイガク,,,ザイガク,ダイガクザイガクチュウ,大学在学中
@@ -9065,6 +9381,7 @@
 
 # newdoc id = dev-s320
 # sent_id = dev-s320
+# parallel_id = jagsd/dev320
 # text = 私たちはビュッフェスタイルだったのですが、いろいろなプランでやってくれるみたいです。
 1	私	私	PRON	代名詞	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシタチ,私達
 2	たち	達	NOUN	接尾辞-名詞的-一般	_	5	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=タチ,達,たち,たち,タチ,,,タチ,ワタシタチ,私達
@@ -9090,6 +9407,7 @@
 
 # newdoc id = dev-s321
 # sent_id = dev-s321
+# parallel_id = jagsd/dev321
 # text = 豚が美味しかったので、また行きます。
 1	豚	豚	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ブタ,豚,豚,豚,ブタ,,,ブタ,ブタ,豚
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9105,6 +9423,7 @@
 
 # newdoc id = dev-s322
 # sent_id = dev-s322
+# parallel_id = jagsd/dev322
 # text = 同百貨店は「成長していく東京スカイツリーをリアルに体感してもらいたい」としている。
 1	同	同	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウ,同,同,同,ドー,,,ドウ,ドウヒャッカテン,同百貨店
 2	百貨	百貨	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒャッカ,百貨,百貨,百貨,ヒャッカ,,,ヒャッカ,ドウヒャッカテン,同百貨店
@@ -9135,6 +9454,7 @@
 
 # newdoc id = dev-s323
 # sent_id = dev-s323
+# parallel_id = jagsd/dev323
 # text = ウエイトが増え、トレードマークだった金髪のロングヘアもすっかり薄くなったことから、それまでの伊達男キャラクターを完全に払拭。
 1	ウエイト	ウエート	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ウエート,ウエート,ウエイト,ウエイト,ウエート,,,ウエイト,ウエイト,ウエイト
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9168,6 +9488,7 @@
 
 # newdoc id = dev-s324
 # sent_id = dev-s324
+# parallel_id = jagsd/dev324
 # text = ヨーロッパで重要なロマネスク建築の一つで、ユネスコの世界遺産に登録されている。
 1	ヨーロッパ	ヨーロッパ	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ヨーロッパ,ヨーロッパ,ヨーロッパ,ヨーロッパ,ヨーロッパ,,,ヨーロッパ,ヨーロッパ,ヨーロッパ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9194,6 +9515,7 @@
 
 # newdoc id = dev-s325
 # sent_id = dev-s325
+# parallel_id = jagsd/dev325
 # text = 本当に健康な人は,身体だけでなく肌もきれいです。
 1	本当	本当	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホントウ,本当,本当,本当,ホント,,,ホント,ホントウ,本当
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9214,6 +9536,7 @@
 
 # newdoc id = dev-s326
 # sent_id = dev-s326
+# parallel_id = jagsd/dev326
 # text = 2万人を収容可能。
 1	2	2	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニ,二,2,2,ニ,,,ニ,ニマンニン,2万人
 2	万	万	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マン,万,万,万,マン,,,マン,ニマンニン,2万人
@@ -9225,6 +9548,7 @@
 
 # newdoc id = dev-s327
 # sent_id = dev-s327
+# parallel_id = jagsd/dev327
 # text = これでも関係がないと言えるのか?
 1	これ	此れ	PRON	代名詞	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9240,6 +9564,7 @@
 
 # newdoc id = dev-s328
 # sent_id = dev-s328
+# parallel_id = jagsd/dev328
 # text = お医者さんも、日大の大学病院で脳神経外科にて手術などの実績が多数あり、脳神経外科を経て同じく耳鼻科の教授にスカウトされ脳の近くの部位である耳鼻咽喉科にて実績を積んだ優秀な先生と聞いています。
 1	お	御	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オイシャサン,御医者さん
 2	医者	医者	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イシャ,医者,医者,医者,イシャ,,,イシャ,オイシャサン,御医者さん
@@ -9305,6 +9630,7 @@
 
 # newdoc id = dev-s329
 # sent_id = dev-s329
+# parallel_id = jagsd/dev329
 # text = それに,病気を治す力も知識もない人間がさも病気を治せるかのように言っていただけなのであれば,そもそも10円だって払う筋合いはないでしょう。
 1	それ	其れ	PRON	代名詞	_	41	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9352,6 +9678,7 @@
 
 # newdoc id = dev-s330
 # sent_id = dev-s330
+# parallel_id = jagsd/dev330
 # text = 若い脳細胞に与える傷は,一生消えないでしょう。
 1	若い	若い	ADJ	形容詞-一般-形容詞	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=ワカイ,若い,若い,若い,ワカイ,,,ワカイ,ワカイ,若い
 2	脳	脳	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ノウ,脳,脳,脳,ノー,,,ノウ,ノウサイボウ,脳細胞
@@ -9369,6 +9696,7 @@
 
 # newdoc id = dev-s331
 # sent_id = dev-s331
+# parallel_id = jagsd/dev331
 # text = 1225年にバーベンベルク家のオーストリア公レオポルト6世の娘マルガレーテと結婚、ハインリヒ8世とフリードリヒ4世を儲けたがいずれも若くして早世した。
 1	1225	1225	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一二二五,1225,1225,イチニニゴ,,,イチニニゴ,イチニニゴネン,1225年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	16	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチニニゴネン,1225年
@@ -9410,6 +9738,7 @@
 
 # newdoc id = dev-s332
 # sent_id = dev-s332
+# parallel_id = jagsd/dev332
 # text = 午前中の西光寺と違って,かなり広大な境内だったため,門の外からはモニターも見えずスピーカーからの声も聞き取れません。
 1	午前	午前	NOUN	名詞-普通名詞-副詞可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴゼン,午前,午前,午前,ゴゼン,,,ゴゼン,ゴゼンチュウ,午前中
 2	中	中	NOUN	接尾辞-名詞的-副詞可能	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チュウ,中,中,中,チュー,,,チュウ,ゴゼンチュウ,午前中
@@ -9449,6 +9778,7 @@
 
 # newdoc id = dev-s333
 # sent_id = dev-s333
+# parallel_id = jagsd/dev333
 # text = 松濤本部では拉致問題対策委員長補佐を務めているようだ。
 1	松濤	松濤	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショートー,ショートー,松濤,松濤,ショートー,,,ショートー,ショートーホンブ,松濤本部
 2	本部	本部	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホンブ,本部,本部,本部,ホンブ,,,ホンブ,ショートーホンブ,松濤本部
@@ -9470,6 +9800,7 @@
 
 # newdoc id = dev-s334
 # sent_id = dev-s334
+# parallel_id = jagsd/dev334
 # text = この日は、被害者の会の14人と弁護士3人が市役所を訪れ、福地直樹弁護士が「真相究明と被害救済のため、必要な措置を講じて欲しい」と述べて要請書を提出。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	日	日	NOUN	名詞-普通名詞-副詞可能	_	21	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ヒ,,,ヒ,ヒ,日
@@ -9526,6 +9857,7 @@
 
 # newdoc id = dev-s335
 # sent_id = dev-s335
+# parallel_id = jagsd/dev335
 # text = 魔法使いへの直接干渉に特化した唯一の魔法大系。
 1	魔法	魔法	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マホウ,魔法,魔法,魔法,マホー,,,マホウ,マホウツカイ,魔法使い
 2	使い	使い	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ツカイ,使い,使い,使い,ツカイ,,,ツカイ,マホウツカイ,魔法使い
@@ -9545,6 +9877,7 @@
 
 # newdoc id = dev-s336
 # sent_id = dev-s336
+# parallel_id = jagsd/dev336
 # text = しかし、国民各層にはその考え方が次第に浸透して行き、自由民権運動の気運が高まるきっかけとなった。
 1	しかし	然し	CCONJ	接続詞	_	27	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9578,6 +9911,7 @@
 
 # newdoc id = dev-s337
 # sent_id = dev-s337
+# parallel_id = jagsd/dev337
 # text = また髪型も京風の引き鬢ではなく、江戸風の出し鬢であった。
 1	また	又	CCONJ	接続詞	_	16	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	髪型	髪型	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カミガタ,髪型,髪型,髪型,カミガタ,,,カミガタ,カミガタ,髪型
@@ -9602,6 +9936,7 @@
 
 # newdoc id = dev-s338
 # sent_id = dev-s338
+# parallel_id = jagsd/dev338
 # text = 1940年7月、オデッサ軍管区の第35狙撃軍団長となり、ベッサラビアの占領に参加した。
 1	1940	1940	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九四ゼロ,1940,1940,イチキューヨンゼロ,,,イチキュウヨンゼロ,イチキュウヨンゼロネン,1940年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチキュウヨンゼロネン,1940年
@@ -9631,6 +9966,7 @@
 
 # newdoc id = dev-s339
 # sent_id = dev-s339
+# parallel_id = jagsd/dev339
 # text = スタンディングでわいわいも2Fテーブル席でまったりでも楽しめる泡なドリンク専門のスタンディングバー。
 1	スタンディング	スタンディング	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スタンディング,スタンディング,スタンディング,スタンディング,スタンディング,,,スタンディング,スタンディング,スタンディング
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9656,6 +9992,7 @@
 
 # newdoc id = dev-s340
 # sent_id = dev-s340
+# parallel_id = jagsd/dev340
 # text = ところが2ちゃんねるの幸福の科学統合スレッドでは,この“主催者発表数”に疑問の声が挙がりました。
 1	ところ	所	CCONJ	名詞-普通名詞-副詞可能	_	26	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=トコロ,所,ところ,ところ,トコロ,,,トコロ,トコロガ,所が
 2	が	が	ADP	助詞-格助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,トコロガ,所が
@@ -9689,6 +10026,7 @@
 
 # newdoc id = dev-s341
 # sent_id = dev-s341
+# parallel_id = jagsd/dev341
 # text = 実験室を1カ所に集めたオープンラボ方式を採用した。
 1	実験	実験	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジッケン,実験,実験,実験,ジッケン,,,ジッケン,ジッケンシツ,実験室
 2	室	室	NOUN	接尾辞-名詞的-一般	_	7	obj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シツ,室,室,室,シツ,,,シツ,ジッケンシツ,実験室
@@ -9709,6 +10047,7 @@
 
 # newdoc id = dev-s342
 # sent_id = dev-s342
+# parallel_id = jagsd/dev342
 # text = JR東日本のクモハ123-1とは種車が同じで、番号も続番となっているが、外観は大きく異なる。
 1	JR	JR	PROPN	名詞-固有名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ジェーアール,ＪＲ,JR,JR,ジェーアール,,,ジェーアール,ジェーアールヒガシニホン,JR東日本
 2	東	東	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ヒガシ,東,東,東,ヒガシ,,,ヒガシ,ジェーアールヒガシニホン,JR東日本
@@ -9744,6 +10083,7 @@
 
 # newdoc id = dev-s343
 # sent_id = dev-s343
+# parallel_id = jagsd/dev343
 # text = 十六日の卒業式が中止になった文教大学越谷校舎の四年生ら学生有志約二百人が越谷市内の駅やスーパーの前などに立ち、被災者救援のために募金を呼び掛けた。
 1	十	十	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ジュウ,十,十,十,ジュー,,,ジュウ,ジュウロクニチ,十六日
 2	六	六	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ロク,六,六,六,ロク,,,ロク,ジュウロクニチ,十六日
@@ -9798,6 +10138,7 @@
 
 # newdoc id = dev-s344
 # sent_id = dev-s344
+# parallel_id = jagsd/dev344
 # text = 東京都生まれ。
 1	東京	東京	PROPN	名詞-固有名詞-地名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウキョウ,トウキョウ,東京,東京,トーキョー,,,トウキョウ,トウキョウトウマレ,東京都生まれ
 2	都	都	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ト,都,都,都,ト,,,ト,トウキョウトウマレ,東京都生まれ
@@ -9806,6 +10147,7 @@
 
 # newdoc id = dev-s345
 # sent_id = dev-s345
+# parallel_id = jagsd/dev345
 # text = 幸福の科学の教えを信じお布施をし,さらに今回のデモに参加したにもかかわらず,教団に守ってもらえないのでは,信者が気の毒です。
 1	幸福	幸福	NOUN	名詞-普通名詞-形状詞可能	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=コウフク,幸福,幸福,幸福,コーフク,,,コウフク,コウフクノカガク,幸福の科学
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,コウフクノカガク,幸福の科学
@@ -9850,6 +10192,7 @@
 
 # newdoc id = dev-s346
 # sent_id = dev-s346
+# parallel_id = jagsd/dev346
 # text = 大阪駅から徒歩10分圏内のスパホテルで、一人旅行でも利用できるし友達とも利用したカプセルホテルです。
 1	大阪	大阪	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=オオサカ,オオサカ,大阪,大阪,オーサカ,,,オオサカ,オオサカエキ,大阪駅
 2	駅	駅	NOUN	名詞-普通名詞-一般	_	8	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=エキ,駅,駅,駅,エキ,,,エキ,オオサカエキ,大阪駅
@@ -9884,6 +10227,7 @@
 
 # newdoc id = dev-s347
 # sent_id = dev-s347
+# parallel_id = jagsd/dev347
 # text = 今回、アメリカ側は6カ国協議の再開に必要な条件を示すための「予備的な米朝協議だ」としていて、北朝鮮の出方を慎重に見極める方針です。
 1	今回	今回	ADV	名詞-普通名詞-副詞可能	_	28	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=コンカイ,今回,今回,今回,コンカイ,,,コンカイ,コンカイ,今回
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9931,6 +10275,7 @@
 
 # newdoc id = dev-s348
 # sent_id = dev-s348
+# parallel_id = jagsd/dev348
 # text = 1985年8月28日生。
 1	1985	1985	NUM	名詞-数詞	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九八五,1985,1985,イチキューハチゴ,,,イチキュウハチゴ,イチキュウハチゴネン,1985年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	7	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチキュウハチゴネン,1985年
@@ -9943,6 +10288,7 @@
 
 # newdoc id = dev-s349
 # sent_id = dev-s349
+# parallel_id = jagsd/dev349
 # text = オハイオ州政府のコンピュータにSETI@homeをインストールして使用したために解雇された例がある。
 1	オハイオ	オハイオ	PROPN	名詞-固有名詞-地名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オハイオ,オハイオ,オハイオ,オハイオ,オハイオ,,,オハイオ,オハイオシュウセイフ,オハイオ州政府
 2	州	州	NOUN	名詞-普通名詞-助数詞可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュウ,州,州,州,シュー,,,シュウ,オハイオシュウセイフ,オハイオ州政府
@@ -9973,6 +10319,7 @@
 
 # newdoc id = dev-s350
 # sent_id = dev-s350
+# parallel_id = jagsd/dev350
 # text = 大震災に対応した特措法の議論も行っており、しかるべく対応したい」と答えました。
 1	大	大	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダイ,大,大,大,ダイ,,,ダイ,ダイシンサイ,大震災
 2	震災	震災	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンサイ,震災,震災,震災,シンサイ,,,シンサイ,ダイシンサイ,大震災
@@ -10003,6 +10350,7 @@
 
 # newdoc id = dev-s351
 # sent_id = dev-s351
+# parallel_id = jagsd/dev351
 # text = それに対し、ヨハンネスの要求は「奴隷500人、牛5万頭、馬1,000頭の貢物と、メネリクを上半身裸にした上で罪人の首枷をつけて謝罪させる」というものだった。
 1	それ	其れ	PRON	代名詞	_	50	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニタイシ,に対し
@@ -10060,6 +10408,7 @@
 
 # newdoc id = dev-s352
 # sent_id = dev-s352
+# parallel_id = jagsd/dev352
 # text = 以来、約10カ月ぶりに横田が復活。
 1	以来	以来	ADV	名詞-普通名詞-副詞可能	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イライ,以来,以来,以来,イライ,,,イライ,イライ,以来
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10075,6 +10424,7 @@
 
 # newdoc id = dev-s353
 # sent_id = dev-s353
+# parallel_id = jagsd/dev353
 # text = MTXの適応が無い患者に対する第二選択薬として用いられることが多い。
 1	MTX	MTX	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エムティーエックス,ＭＴＸ,MTX,MTX,エムティーエックス,,,エムティーエックス,エムティーエックス,MTX
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10100,6 +10450,7 @@
 
 # newdoc id = dev-s354
 # sent_id = dev-s354
+# parallel_id = jagsd/dev354
 # text = 体力とボールパワーが高いが、素早さが低い。
 1	体力	体力	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タイリョク,体力,体力,体力,タイリョク,,,タイリョク,タイリョク,体力
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -10117,6 +10468,7 @@
 
 # newdoc id = dev-s355
 # sent_id = dev-s355
+# parallel_id = jagsd/dev355
 # text = しかし彼のホームレス支援活動が悪いことだとは思えません。
 1	しかし	然し	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	彼	彼	PRON	代名詞	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=カレ,彼,彼,彼,カレ,,,カレ,カレ,彼
@@ -10137,6 +10489,7 @@
 
 # newdoc id = dev-s356
 # sent_id = dev-s356
+# parallel_id = jagsd/dev356
 # text = その日はたまたまサービスで生肉を出して頂いたが、味、食感ともに大した事はなかった。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	日	日	NOUN	名詞-普通名詞-副詞可能	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ヒ,,,ヒ,ヒ,日
@@ -10166,6 +10519,7 @@
 
 # newdoc id = dev-s357
 # sent_id = dev-s357
+# parallel_id = jagsd/dev357
 # text = 1967年、アレクサンダーは連邦上院議員ハワード・ベイカーの議会補佐官として勤務した。
 1	1967	1967	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九六七,1967,1967,イチキューロクシチ,,,イチキュウロクシチ,イチキュウロクシチネン,1967年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	19	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチキュウロクシチネン,1967年
@@ -10192,6 +10546,7 @@
 
 # newdoc id = dev-s358
 # sent_id = dev-s358
+# parallel_id = jagsd/dev358
 # text = 自然を愛するため、同様の性格を持つタイガトロンと共に行動することが多いが、「基地は性に合わない」と零すタイガトロンと違い、特に合わない素振りは見せていない。
 1	自然	自然	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シゼン,自然,自然,自然,シゼン,,,シゼン,シゼン,自然
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -10241,6 +10596,7 @@
 
 # newdoc id = dev-s359
 # sent_id = dev-s359
+# parallel_id = jagsd/dev359
 # text = 県指定重要文化財・くまもとアートポリス選定既存建造物。
 1	県	県	NOUN	名詞-普通名詞-一般	_	13	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケン,県,県,県,ケン,,,ケン,ケンシテイジュウヨウブンカザイクマモトアートポリスセンテイキソンケンゾウブツ,県指定重要文化財・くまもとアートポリス選定既存建造物
 2	指定	指定	NOUN	名詞-普通名詞-サ変可能	_	13	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シテイ,指定,指定,指定,シテー,,,シテイ,ケンシテイジュウヨウブンカザイクマモトアートポリスセンテイキソンケンゾウブツ,県指定重要文化財・くまもとアートポリス選定既存建造物
@@ -10259,6 +10615,7 @@
 
 # newdoc id = dev-s360
 # sent_id = dev-s360
+# parallel_id = jagsd/dev360
 # text = 病院に行かず治療も受けずになくなっています。
 1	病院	病院	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ビョウイン,病院,病院,病院,ビョーイン,,,ビョウイン,ビョウイン,病院
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -10277,6 +10634,7 @@
 
 # newdoc id = dev-s361
 # sent_id = dev-s361
+# parallel_id = jagsd/dev361
 # text = 同時上映は『・ふ・た・り・ぼ・っ・ち・』。
 1	同時	同時	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウジ,同時,同時,同時,ドージ,,,ドウジ,ドウジジョウエイ,同時上映
 2	上映	上映	NOUN	名詞-普通名詞-サ変可能	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョウエイ,上映,上映,上映,ジョーエー,,,ジョウエイ,ドウジジョウエイ,同時上映
@@ -10289,6 +10647,7 @@
 
 # newdoc id = dev-s362
 # sent_id = dev-s362
+# parallel_id = jagsd/dev362
 # text = 飲んだ後に行きたくなる。
 1	飲ん	飲む	VERB	動詞-一般-五段-マ行	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-マ行|SpaceAfter=No|UnidicInfo=ノム,飲む,飲ん,飲む,ノン,,,ノム,ノム,飲む
 2	だ	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-タ|SpaceAfter=No|UnidicInfo=タ,た,だ,だ,ダ,,,ダ,ダ,だ
@@ -10301,6 +10660,7 @@
 
 # newdoc id = dev-s363
 # sent_id = dev-s363
+# parallel_id = jagsd/dev363
 # text = 官位は従四位上・参議。
 1	官位	官位	NOUN	名詞-普通名詞-一般	_	8	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カンイ,官位,官位,官位,カンイ,,,カンイ,カンイ,官位
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10314,6 +10674,7 @@
 
 # newdoc id = dev-s364
 # sent_id = dev-s364
+# parallel_id = jagsd/dev364
 # text = 日本に馴染み、短い間に日本語を覚えたセルギイは、日露戦争の結果、日本が獲得した樺太で没収された資産を信徒に返還するため、正教徒のスポークスマンとして活動した。
 1	日本	日本	PROPN	名詞-固有名詞-地名-国	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニッポン,,,ニッポン,ニッポン,日本
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -10368,6 +10729,7 @@
 
 # newdoc id = dev-s365
 # sent_id = dev-s365
+# parallel_id = jagsd/dev365
 # text = ちなみに、大阪市は現在の長居公園に1951年11月、大阪競馬場を利用して、市営の長居オートレース場も開設したが、爆音にかかる周辺環境問題や経営不振を理由に、わずか5ヶ月で廃止した。
 1	ちなみ	因み	CCONJ	名詞-普通名詞-一般	_	54	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=チナミ,因み,ちなみ,ちなみ,チナミ,,,チナミ,チナミニ,因みに
 2	に	に	ADP	助詞-格助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,チナミニ,因みに
@@ -10429,6 +10791,7 @@
 
 # newdoc id = dev-s366
 # sent_id = dev-s366
+# parallel_id = jagsd/dev366
 # text = 幸福実現党では,唯一の国会議員であった大江康弘参議院議員も昨年末に離党しています。
 1	幸福	幸福	NOUN	名詞-普通名詞-形状詞可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=コウフク,幸福,幸福,幸福,コーフク,,,コウフク,コウフクジツゲントウ,幸福実現党
 2	実現	実現	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ジツゲン,実現,実現,実現,ジツゲン,,,ジツゲン,コウフクジツゲントウ,幸福実現党
@@ -10461,6 +10824,7 @@
 
 # newdoc id = dev-s367
 # sent_id = dev-s367
+# parallel_id = jagsd/dev367
 # text = この後結成した「アテナ&ロビケロッツ」「ガーディアンズ4」、また2009年6月にチャンプルユニットとして結成されたタンポポ#・プッチモニV・ZYX-α・続・美勇伝にも選抜参加したメンバーがいる。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	後	後	NOUN	名詞-普通名詞-副詞可能	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アト,後,後,後,アト,,,アト,アト,後
@@ -10521,6 +10885,7 @@
 
 # newdoc id = dev-s368
 # sent_id = dev-s368
+# parallel_id = jagsd/dev368
 # text = 玉子チリソースも気になった。
 1	玉子	卵	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タマゴ,卵,玉子,玉子,タマゴ,,,タマゴ,タマゴチリソース,卵チリソース
 2	チリ	チリ	PROPN	名詞-固有名詞-地名-国	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チリ,チリ,チリ,チリ,チリ,,,チリ,タマゴチリソース,卵チリソース
@@ -10534,6 +10899,7 @@
 
 # newdoc id = dev-s369
 # sent_id = dev-s369
+# parallel_id = jagsd/dev369
 # text = その後、1948年8月25日の代議員選挙によって北朝鮮最高人民会議が設立され、9月3日には北朝鮮憲法が公式採択された。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-副詞可能	_	22	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -10578,6 +10944,7 @@
 
 # newdoc id = dev-s370
 # sent_id = dev-s370
+# parallel_id = jagsd/dev370
 # text = 最後に穀物の珈琲とデザートまで付いてくるのです。
 1	最後	最後	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サイゴ,最後,最後,最後,サイゴ,,,サイゴ,サイゴ,最後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -10596,6 +10963,7 @@
 
 # newdoc id = dev-s371
 # sent_id = dev-s371
+# parallel_id = jagsd/dev371
 # text = ディスクを取り外し可能なハードディスクのこと。
 1	ディスク	ディスク	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ディスク,ディスク,ディスク,ディスク,ディスク,,,ディスク,ディスク,ディスク
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -10609,6 +10977,7 @@
 
 # newdoc id = dev-s372
 # sent_id = dev-s372
+# parallel_id = jagsd/dev372
 # text = NPTLはRed Hat Enterprise Linuxのバージョン3から搭載され、現在ではGNU Cライブラリの一部となっている。
 1	NPTL	NPTL	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エヌピーティーエル,ＮＰＴＬ,NPTL,NPTL,エヌピーティーエル,,,エヌピーティーエル,エヌピーティーエル,NPTL
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10640,6 +11009,7 @@
 
 # newdoc id = dev-s373
 # sent_id = dev-s373
+# parallel_id = jagsd/dev373
 # text = フェレット装甲車の設計と形状は前任のダイムラー偵察車との共通点が多いが、フェレット装甲車はダイムラー偵察車よりも戦闘区画が広く小さな機関銃付の砲塔を装備している。
 1	フェレット	フェレット	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フェレット,フェレット,フェレット,フェレット,フェレット,,,フェレット,フェレットソウコウシャ,フェレット装甲車
 2	装甲	装甲	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ソウコウ,装甲,装甲,装甲,ソーコー,,,ソウコウ,フェレットソウコウシャ,フェレット装甲車
@@ -10690,6 +11060,7 @@
 
 # newdoc id = dev-s374
 # sent_id = dev-s374
+# parallel_id = jagsd/dev374
 # text = 作中では、皇一心や率いる集団の社会階級の明確な描写はされていない。
 1	作中	作中	NOUN	名詞-普通名詞-一般	_	18	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サクチュウ,作中,作中,作中,サクチュー,,,サクチュウ,サクチュウ,作中
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -10717,6 +11088,7 @@
 
 # newdoc id = dev-s375
 # sent_id = dev-s375
+# parallel_id = jagsd/dev375
 # text = また“名進信徒会”の所在地についても“わかりません”。
 1	また	又	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	“	“	PUNCT	補助記号-括弧開	_	5	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
@@ -10740,6 +11112,7 @@
 
 # newdoc id = dev-s376
 # sent_id = dev-s376
+# parallel_id = jagsd/dev376
 # text = いつも飲み慣れている祖父が、突然、割ってあると言い出したのです。
 1	いつ	何時	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=イツ,何時,いつ,いつ,イツ,,,イツ,イツ,何時
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -10765,6 +11138,7 @@
 
 # newdoc id = dev-s377
 # sent_id = dev-s377
+# parallel_id = jagsd/dev377
 # text = ポール・ウェラーからセッションやオープニングアクトのオファーを受けるなど、高い評価を得ている。
 1	ポール	ポール	PROPN	名詞-固有名詞-人名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ポール,ポール,ポール,ポール,ポール,,,ポール,ポールウェラー,ポール・ウェラー
 2	・	・	SYM	補助記号-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,ポールウェラー,ポール・ウェラー
@@ -10790,6 +11164,7 @@
 
 # newdoc id = dev-s378
 # sent_id = dev-s378
+# parallel_id = jagsd/dev378
 # text = しかし、憲法訴訟という類型自体が存在しないとしても、憲法判断の重要性から、憲法訴訟に特有の理論を考察する学問分野がある。
 1	しかし	然し	CCONJ	接続詞	_	37	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -10832,6 +11207,7 @@
 
 # newdoc id = dev-s379
 # sent_id = dev-s379
+# parallel_id = jagsd/dev379
 # text = 最も知られた蔵本モデルの形式は次のような支配方程式に従う。
 1	最も	最も	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=モットモ,最も,最も,最も,モットモ,,,モットモ,モットモ,最も
 2	知ら	知る	VERB	動詞-一般-五段-ラ行	_	6	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-ラ行|SpaceAfter=No|UnidicInfo=シル,知る,知ら,知る,シラ,,,シル,シル,知る
@@ -10855,6 +11231,7 @@
 
 # newdoc id = dev-s380
 # sent_id = dev-s380
+# parallel_id = jagsd/dev380
 # text = 彼に関する本を何冊も読みましたし,彼のプレゼンをYou Tubeで見ては興奮していました。
 1	彼	彼	PRON	代名詞	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=カレ,彼,彼,彼,カレ,,,カレ,カレ,彼
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニカンスル,に関する
@@ -10889,6 +11266,7 @@
 
 # newdoc id = dev-s381
 # sent_id = dev-s381
+# parallel_id = jagsd/dev381
 # text = アメリカの研究者や中国の臨床試験で,免疫システムの病気であるリューマチにも効果がすぐれているということも証明されました。
 1	アメリカ	アメリカ	PROPN	名詞-固有名詞-地名-国	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=アメリカ,アメリカ,アメリカ,アメリカ,アメリカ,,,アメリカ,アメリカ,アメリカ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10928,6 +11306,7 @@
 
 # newdoc id = dev-s382
 # sent_id = dev-s382
+# parallel_id = jagsd/dev382
 # text = 新宿の高速バスを利用するときは必ず足を運んでしまう。
 1	新宿	新宿	PROPN	名詞-固有名詞-地名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=シンジュク,シンジュク,新宿,新宿,シンジュク,,,シンジュク,シンジュク,新宿
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10948,6 +11327,7 @@
 
 # newdoc id = dev-s383
 # sent_id = dev-s383
+# parallel_id = jagsd/dev383
 # text = お店の雰囲気も活気がある感じが気に入っています。
 1	お	御	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オミセ,御店
 2	店	店	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ミセ,店,店,店,ミセ,,,ミセ,オミセ,御店
@@ -10969,6 +11349,7 @@
 
 # newdoc id = dev-s384
 # sent_id = dev-s384
+# parallel_id = jagsd/dev384
 # text = 1979年、DECを辞めて作家専業となり、フロリダ州オーランドに移住した。
 1	1979	1979	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九七九,1979,1979,イチキューナナキュー,,,イチキュウナナキュウ,イチキュウナナキュウネン,1979年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	17	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチキュウナナキュウネン,1979年
@@ -10993,6 +11374,7 @@
 
 # newdoc id = dev-s385
 # sent_id = dev-s385
+# parallel_id = jagsd/dev385
 # text = 板門店内および共同警備区域においては、韓国軍を中心とした国連軍と、北朝鮮軍の両軍が境界線を隔てて顔を合わせ警備についている。
 1	板門店	板門店	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハンモンテン,ハンモンテン,板門店,板門店,ハンモンテン,,,ハンモンテン,ハンモンテンナイ,板門店内
 2	内	内	NOUN	接尾辞-名詞的-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナイ,内,内,内,ナイ,,,ナイ,ハンモンテンナイ,板門店内
@@ -11038,6 +11420,7 @@
 
 # newdoc id = dev-s386
 # sent_id = dev-s386
+# parallel_id = jagsd/dev386
 # text = 以上の方面は、当駅は途中バス停である。
 1	以上	以上	NOUN	名詞-普通名詞-副詞可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イジョウ,以上,以上,以上,イジョー,,,イジョウ,イジョウ,以上
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11055,6 +11438,7 @@
 
 # newdoc id = dev-s387
 # sent_id = dev-s387
+# parallel_id = jagsd/dev387
 # text = 子どもが熱をだしとても親切に診ていただきました。
 1	子ども	子供	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コドモ,子供,子ども,子ども,コドモ,,,コドモ,コドモ,子共
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -11073,6 +11457,7 @@
 
 # newdoc id = dev-s388
 # sent_id = dev-s388
+# parallel_id = jagsd/dev388
 # text = そこで今月19日に開かれた“家系のおはなし”講演会に参加した。
 1	そこ	其処	PRON	代名詞	_	19	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ソコ,其処,そこ,そこ,ソコ,,,ソコ,ソコ,其処
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11099,6 +11484,7 @@
 
 # newdoc id = dev-s389
 # sent_id = dev-s389
+# parallel_id = jagsd/dev389
 # text = 当初は2008年4月1日から2011年3月31日までの3年間の契約で命名権が売却されたが、2010年12月-2011年1月にかけて実施された同ホールの命名権募集に穴吹興産1社しか応募がなかったため、同社との間で2011年4月1日から2016年3月31日の5年間の契約で命名権が売却された。
 1	当初	当初	NOUN	名詞-普通名詞-副詞可能	_	26	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11200,6 +11586,7 @@
 
 # newdoc id = dev-s390
 # sent_id = dev-s390
+# parallel_id = jagsd/dev390
 # text = 昔話を聞くと興奮して発砲する。
 1	昔話	昔話	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ムカシバナシ,昔話,昔話,昔話,ムカシバナシ,,,ムカシバナシ,ムカシバナシ,昔話
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -11214,6 +11601,7 @@
 
 # newdoc id = dev-s391
 # sent_id = dev-s391
+# parallel_id = jagsd/dev391
 # text = 由来はヤコブから。
 1	由来	由来	NOUN	名詞-普通名詞-サ変可能	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ユライ,由来,由来,由来,ユライ,,,ユライ,ユライ,由来
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11223,6 +11611,7 @@
 
 # newdoc id = dev-s392
 # sent_id = dev-s392
+# parallel_id = jagsd/dev392
 # text = ブルジョア教育を最も推進しているのは,日本共産党である。
 1	ブルジョア	ブルジョア	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ブルジョア,ブルジョア,ブルジョア,ブルジョア,ブルジョア,,,ブルジョア,ブルジョアキョウイク,ブルジョア教育
 2	教育	教育	NOUN	名詞-普通名詞-サ変可能	_	5	obj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウイク,教育,教育,教育,キョーイク,,,キョウイク,ブルジョアキョウイク,ブルジョア教育
@@ -11244,6 +11633,7 @@
 
 # newdoc id = dev-s393
 # sent_id = dev-s393
+# parallel_id = jagsd/dev393
 # text = 部屋へ入るとドライヤーや鏡があり、明らかに宿泊用の部屋といった感じでした。
 1	部屋	部屋	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヘヤ,部屋,部屋,部屋,ヘヤ,,,ヘヤ,ヘヤ,部屋
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -11271,6 +11661,7 @@
 
 # newdoc id = dev-s394
 # sent_id = dev-s394
+# parallel_id = jagsd/dev394
 # text = それに加えて,毎月の損失を50%以上軽減するための大規模な努力がなされました。
 1	それ	其れ	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11301,6 +11692,7 @@
 
 # newdoc id = dev-s395
 # sent_id = dev-s395
+# parallel_id = jagsd/dev395
 # text = そのほかの主要任務としては「レーベンスボルン」と「アーネンエルベ」の実質的な運営があった。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ほか	他	NOUN	名詞-普通名詞-副詞可能	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
@@ -11330,6 +11722,7 @@
 
 # newdoc id = dev-s396
 # sent_id = dev-s396
+# parallel_id = jagsd/dev396
 # text = 警視庁や証券取引等監視委員会と合同で一斉捜索する見通し。
 1	警視	警視	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ケイシ,警視,警視,警視,ケーシ,,,ケイシ,ケイシチョウ,警視庁
 2	庁	庁	NOUN	接尾辞-名詞的-一般	_	9	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=チョウ,庁,庁,庁,チョー,,,チョウ,ケイシチョウ,警視庁
@@ -11351,6 +11744,7 @@
 
 # newdoc id = dev-s397
 # sent_id = dev-s397
+# parallel_id = jagsd/dev397
 # text = 2005年にオランダのスパルタ・ロッテルダムへ移籍した。
 1	2005	2005	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ五,2005,2005,ニゼロゼロゴ,,,ニゼロゼロゴ,ニゼロゼロゴネン,2005年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	10	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロゴネン,2005年
@@ -11368,6 +11762,7 @@
 
 # newdoc id = dev-s398
 # sent_id = dev-s398
+# parallel_id = jagsd/dev398
 # text = 2013年、栃木SCのシニアアドバイザーに就任。
 1	2013	2013	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロ一三,2013,2013,ニゼロイチサン,,,ニゼロイチサン,ニゼロイチサンネン,2013年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	10	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロイチサンネン,2013年
@@ -11383,6 +11778,7 @@
 
 # newdoc id = dev-s399
 # sent_id = dev-s399
+# parallel_id = jagsd/dev399
 # text = 元々は、済美女子高等学校であったが、2004年4月から男女共学部普通科を設置し、名称が済美高等学校となった。
 1	元々	元々	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=モトモト,元々,元々,元々,モトモト,,,モトモト,モトモト,元々
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11422,6 +11818,7 @@
 
 # newdoc id = dev-s400
 # sent_id = dev-s400
+# parallel_id = jagsd/dev400
 # text = ハーダーは第二次世界大戦の戦功で6個の従軍星章を受章した。
 1	ハーダー	ハーダー	PROPN	名詞-固有名詞-人名-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ハーダー,ハーダー,ハーダー,ハーダー,ハーダー,,,ハーダー,ハーダー,ハーダー
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11446,6 +11843,7 @@
 
 # newdoc id = dev-s401
 # sent_id = dev-s401
+# parallel_id = jagsd/dev401
 # text = かつては、塩山-丹波-奥多摩駅という形で山梨交通との相互乗り入れを行っていたが、利用客の減少などにより、1972年で廃止になっている。
 1	かつて	嘗て	ADV	副詞	_	21	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=カツテ,嘗て,かつて,かつて,カツテ,,,カツテ,カツテ,嘗て
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11493,6 +11891,7 @@
 
 # newdoc id = dev-s402
 # sent_id = dev-s402
+# parallel_id = jagsd/dev402
 # text = 所属事務所は米朝事務所。
 1	所属	所属	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショゾク,所属,所属,所属,ショゾク,,,ショゾク,ショゾクジムショ,所属事務所
 2	事務	事務	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジム,事務,事務,事務,ジム,,,ジム,ショゾクジムショ,所属事務所
@@ -11505,6 +11904,7 @@
 
 # newdoc id = dev-s403
 # sent_id = dev-s403
+# parallel_id = jagsd/dev403
 # text = 狭いお店だけど、パンだけじゃなく結構変わったかりんとうなんかも売ってました。
 1	狭い	狭い	ADJ	形容詞-一般-形容詞	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=セマイ,狭い,狭い,狭い,セマイ,,,セマイ,セマイ,狭い
 2	お	御	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オミセ,御店
@@ -11532,6 +11932,7 @@
 
 # newdoc id = dev-s404
 # sent_id = dev-s404
+# parallel_id = jagsd/dev404
 # text = 拉致監禁強制改宗は犯罪だ!
 1	拉致	拉致	NOUN	名詞-普通名詞-サ変可能	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ラチ,拉致,拉致,拉致,ラチ,,,ラチ,ラチカンキンキョウセイカイシュウ,拉致監禁強制改宗
 2	監禁	監禁	NOUN	名詞-普通名詞-サ変可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カンキン,監禁,監禁,監禁,カンキン,,,カンキン,ラチカンキンキョウセイカイシュウ,拉致監禁強制改宗
@@ -11544,6 +11945,7 @@
 
 # newdoc id = dev-s405
 # sent_id = dev-s405
+# parallel_id = jagsd/dev405
 # text = 京成本線町屋駅-千住大橋駅の間に存在していた。
 1	京成	京成	PROPN	名詞-固有名詞-一般	_	8	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケイセイ,京成,京成,京成,ケーセー,,,ケイセイ,ケイセイホンセンマチヤエキセンジュオオハシエキ,京成本線町家駅-千住大橋駅
 2	本線	本線	NOUN	名詞-普通名詞-一般	_	8	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホンセン,本線,本線,本線,ホンセン,,,ホンセン,ケイセイホンセンマチヤエキセンジュオオハシエキ,京成本線町家駅-千住大橋駅
@@ -11565,6 +11967,7 @@
 
 # newdoc id = dev-s406
 # sent_id = dev-s406
+# parallel_id = jagsd/dev406
 # text = 製品生産者たちはまだ自らのウェブサイトで広告するという手段を持っておらず、宣伝には「AOL Key words」を利用していた。
 1	製品	製品	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイヒン,製品,製品,製品,セーヒン,,,セイヒン,セイヒンセイサンシャタチ,製品生産者達
 2	生産	生産	NOUN	名詞-普通名詞-サ変可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイサン,生産,生産,生産,セーサン,,,セイサン,セイヒンセイサンシャタチ,製品生産者達
@@ -11605,6 +12008,7 @@
 
 # newdoc id = dev-s407
 # sent_id = dev-s407
+# parallel_id = jagsd/dev407
 # text = 1819年から1821年までの間にヴィルヘルムス運河が造られ、特にハイルブロンナー製紙によって発展した工業地域の立地に寄与した。
 1	1819	1819	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一八一九,1819,1819,イチハチイチキュー,,,イチハチイチキュウ,イチハチイチキュウネン,1819年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチハチイチキュウネン,1819年
@@ -11642,6 +12046,7 @@
 
 # newdoc id = dev-s408
 # sent_id = dev-s408
+# parallel_id = jagsd/dev408
 # text = 教団内では“科学技術省次官”の地位にありました。
 1	教団	教団	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウダン,教団,教団,教団,キョーダン,,,キョウダン,キョウダンナイ,教団内
 2	内	内	NOUN	接尾辞-名詞的-一般	_	14	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナイ,内,内,内,ナイ,,,ナイ,キョウダンナイ,教団内
@@ -11663,6 +12068,7 @@
 
 # newdoc id = dev-s409
 # sent_id = dev-s409
+# parallel_id = jagsd/dev409
 # text = 強い香りを持つ植物である。
 1	強い	強い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=ツヨイ,強い,強い,強い,ツヨイ,,,ツヨイ,ツヨイ,強い
 2	香り	香り	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カオリ,香り,香り,香り,カオリ,,,カオリ,カオリ,香り
@@ -11675,6 +12081,7 @@
 
 # newdoc id = dev-s410
 # sent_id = dev-s410
+# parallel_id = jagsd/dev410
 # text = 女性も大丈夫です。
 1	女性	女性	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョセイ,女性,女性,女性,ジョセー,,,ジョセイ,ジョセイ,女性
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -11684,6 +12091,7 @@
 
 # newdoc id = dev-s411
 # sent_id = dev-s411
+# parallel_id = jagsd/dev411
 # text = 従来予想は微増の19億円。
 1	従来	従来	NOUN	名詞-普通名詞-副詞可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジュウライ,従来,従来,従来,ジューライ,,,ジュウライ,ジュウライヨソウ,従来予想
 2	予想	予想	NOUN	名詞-普通名詞-サ変可能	_	8	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨソウ,予想,予想,予想,ヨソー,,,ヨソウ,ジュウライヨソウ,従来予想
@@ -11697,6 +12105,7 @@
 
 # newdoc id = dev-s412
 # sent_id = dev-s412
+# parallel_id = jagsd/dev412
 # text = この方は,本紙<沖縄知事選めぐり大江議員と幸福実現党が対立>登場された方です。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	方	方	NOUN	名詞-普通名詞-助数詞可能	_	24	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カタ,方,方,方,カタ,,,カタ,カタ,方
@@ -11727,6 +12136,7 @@
 
 # newdoc id = dev-s413
 # sent_id = dev-s413
+# parallel_id = jagsd/dev413
 # text = 1708年にカルロが死ぬと、マントヴァ公位は廃位され、ゴンザーガ家は永久にマントヴァを失い、以後ハプスブルク家支配となった。
 1	1708	1708	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一七ゼロ八,1708,1708,イチナナゼロハチ,,,イチナナゼロハチ,イチナナゼロハチネン,1708年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	6	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチナナゼロハチネン,1708年
@@ -11764,6 +12174,7 @@
 
 # newdoc id = dev-s414
 # sent_id = dev-s414
+# parallel_id = jagsd/dev414
 # text = ちょっとした遊具もあるので小さな子どもさんもいいと思います。
 1	ちょっと	一寸	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=チョット,一寸,ちょっと,ちょっと,チョット,,,チョット,チョットスル,一寸する
 2	し	為る	AUX	動詞-非自立可能-サ行変格	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,チョットスル,一寸する
@@ -11785,6 +12196,7 @@
 
 # newdoc id = dev-s415
 # sent_id = dev-s415
+# parallel_id = jagsd/dev415
 # text = SEXが強すぎるのかも知れない。
 1	SEX	SEX	NOUN	名詞-普通名詞-サ変可能	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セックス,セックス,SEX,SEX,セックス,,,セックス,セックス,SEX
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -11799,6 +12211,7 @@
 
 # newdoc id = dev-s416
 # sent_id = dev-s416
+# parallel_id = jagsd/dev416
 # text = 所属事務所はBreath。
 1	所属	所属	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショゾク,所属,所属,所属,ショゾク,,,ショゾク,ショゾクジムショ,所属事務所
 2	事務	事務	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジム,事務,事務,事務,ジム,,,ジム,ショゾクジムショ,所属事務所
@@ -11809,6 +12222,7 @@
 
 # newdoc id = dev-s417
 # sent_id = dev-s417
+# parallel_id = jagsd/dev417
 # text = 紳助さんは、先月23日の引退記者会見で、十数年前にあったトラブルを解決してくれたのが、暴力団関係者だったことを明らかにした。
 1	紳助	紳助	PROPN	名詞-固有名詞-人名-名	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-名|SpaceAfter=No|UnidicInfo=シンスケ,シンスケ,紳助,紳助,シンスケ,,,シンスケ,シンスケサン,紳助さん
 2	さん	さん	NOUN	接尾辞-名詞的-一般	_	41	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-名|SpaceAfter=No|UnidicInfo=サン,さん,さん,さん,サン,,,サン,シンスケサン,紳助さん
@@ -11856,6 +12270,7 @@
 
 # newdoc id = dev-s418
 # sent_id = dev-s418
+# parallel_id = jagsd/dev418
 # text = 自分の身は自分で守ろう!
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11868,6 +12283,7 @@
 
 # newdoc id = dev-s419
 # sent_id = dev-s419
+# parallel_id = jagsd/dev419
 # text = 清代は湖北省が置かれ、そのまま現代の行政区分になっている。
 1	清代	清代	NOUN	名詞-普通名詞-一般	_	16	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンダイ,清代,清代,清代,シンダイ,,,シンダイ,シンダイ,清代
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11891,6 +12307,7 @@
 
 # newdoc id = dev-s420
 # sent_id = dev-s420
+# parallel_id = jagsd/dev420
 # text = 戦死後に彼の妻から譲られる「ナイトシールド」は、彼の形見でもある。
 1	戦死	戦死	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センシ,戦死,戦死,戦死,センシ,,,センシ,センシゴ,戦死後
 2	後	後	NOUN	接尾辞-名詞的-副詞可能	_	8	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,センシゴ,戦死後
@@ -11917,6 +12334,7 @@
 
 # newdoc id = dev-s421
 # sent_id = dev-s421
+# parallel_id = jagsd/dev421
 # text = 建造物も仏像も中国明朝時代を偲ばせています。
 1	建造	建造	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケンゾウ,建造,建造,建造,ケンゾー,,,ケンゾウ,ケンゾウブツ,建造物
 2	物	物	NOUN	接尾辞-名詞的-一般	_	4	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ブツ,物,物,物,ブツ,,,ブツ,ケンゾウブツ,建造物
@@ -11936,6 +12354,7 @@
 
 # newdoc id = dev-s422
 # sent_id = dev-s422
+# parallel_id = jagsd/dev422
 # text = これからは花こうさんをずっと利用したいと思っています。
 1	これ	此れ	PRON	代名詞	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -11956,6 +12375,7 @@
 
 # newdoc id = dev-s423
 # sent_id = dev-s423
+# parallel_id = jagsd/dev423
 # text = また、この番組は公開録音スタイルがとられており、当初は改装前の第3スタジオでギャラリーも5~6人だったが、その後常時10人以上集まるように更にギャラリーの数が増えたため広い第1スタジオに移って収録するようになった。
 1	また	又	CCONJ	接続詞	_	62	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -12024,6 +12444,7 @@
 
 # newdoc id = dev-s424
 # sent_id = dev-s424
+# parallel_id = jagsd/dev424
 # text = 同コーナーの放送開始と終了時には、この定点カメラの映像とは別に部屋全体を映す別の固定カメラの映像を使用している。
 1	同	同	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウ,同,同,同,ドー,,,ドウ,ドウコーナー,同コーナー
 2	コーナー	コーナー	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コーナー,コーナー,コーナー,コーナー,コーナー,,,コーナー,ドウコーナー,同コーナー
@@ -12064,6 +12485,7 @@
 
 # newdoc id = dev-s425
 # sent_id = dev-s425
+# parallel_id = jagsd/dev425
 # text = この曲は、1964年のテレビドラマ版の主題歌であると誤解されやすいが、ドラマで使用されたのはシンプルなインストルメンタルBGM曲のみで、青山和子が歌うこのレコード企画とは全く別のプロジェクトである。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	曲	曲	NOUN	名詞-普通名詞-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョク,曲,曲,曲,キョク,,,キョク,キョク,曲
@@ -12122,6 +12544,7 @@
 
 # newdoc id = dev-s426
 # sent_id = dev-s426
+# parallel_id = jagsd/dev426
 # text = ローズクランズはイウカでは縮小されたミシシッピ軍を率い、コリンスではテネシー軍からの2個師団の支援を受けた。
 1	ローズクランズ	ローズクランズ	PROPN	名詞-固有名詞-人名-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ローズクランズ,ローズクランズ,ローズクランズ,ローズクランズ,ローズクランズ,,,ローズクランズ,ローズクランズ,ローズクランズ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12156,6 +12579,7 @@
 
 # newdoc id = dev-s427
 # sent_id = dev-s427
+# parallel_id = jagsd/dev427
 # text = バニラアイスが大好物。
 1	バニラ	バニラ	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バニラ,バニラ,バニラ,バニラ,バニラ,,,バニラ,バニラアイス,バニラアイス
 2	アイス	アイス	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アイス,アイス,アイス,アイス,アイス,,,アイス,バニラアイス,バニラアイス
@@ -12166,6 +12590,7 @@
 
 # newdoc id = dev-s428
 # sent_id = dev-s428
+# parallel_id = jagsd/dev428
 # text = インターネットにおける個人の報道活動の意義と実状を全く無視した,あまりに時代錯誤な最高裁の判決を,本紙は強く非難します。
 1	インターネット	インターネット	NOUN	名詞-普通名詞-一般	_	8	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=インターネット,インターネット,インターネット,インターネット,インターネット,,,インターネット,インターネット,インターネット
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニオケル,における
@@ -12206,6 +12631,7 @@
 
 # newdoc id = dev-s429
 # sent_id = dev-s429
+# parallel_id = jagsd/dev429
 # text = しかし、正恩氏は軍大将として登場し、活動を部隊視察から始めた。
 1	しかし	然し	CCONJ	接続詞	_	19	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -12231,6 +12657,7 @@
 
 # newdoc id = dev-s430
 # sent_id = dev-s430
+# parallel_id = jagsd/dev430
 # text = その3分の2近くが統一教会関係者のようでした。
 1	その	其の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	3	3	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サン,三,3,3,サン,,,サン,サンブンノニチカク,3分の2近く
@@ -12251,6 +12678,7 @@
 
 # newdoc id = dev-s431
 # sent_id = dev-s431
+# parallel_id = jagsd/dev431
 # text = 状況によっては統一教会擁護の論陣を張ろうと思っています。
 1	状況	状況	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョウキョウ,状況,状況,状況,ジョーキョー,,,ジョウキョウ,ジョウキョウ,状況
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニヨッテ,によって
@@ -12273,6 +12701,7 @@
 
 # newdoc id = dev-s432
 # sent_id = dev-s432
+# parallel_id = jagsd/dev432
 # text = 治療はステロイドの内服が中心だという。
 1	治療	治療	NOUN	名詞-普通名詞-サ変可能	_	7	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チリョウ,治療,治療,治療,チリョー,,,チリョウ,チリョウ,治療
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12288,6 +12717,7 @@
 
 # newdoc id = dev-s433
 # sent_id = dev-s433
+# parallel_id = jagsd/dev433
 # text = 彼女は、ロサンゼルスでのより高いステータスを得られる仕事のオファーを受け入れたのだった。
 1	彼女	彼女	PRON	代名詞	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=カノジョ,彼女,彼女,彼女,カノジョ,,,カノジョ,カノジョ,彼女
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12314,6 +12744,7 @@
 
 # newdoc id = dev-s434
 # sent_id = dev-s434
+# parallel_id = jagsd/dev434
 # text = 「唯識三十頌」では上述の八識説を唱え、部分的に深層心理学的傾向や生物学的傾向を示した。
 1	「	「	PUNCT	補助記号-括弧開	_	4	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	唯識	唯識	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ユイシキ,唯識,唯識,唯識,ユイシキ,,,ユイシキ,ユイシキ,唯識
@@ -12349,6 +12780,7 @@
 
 # newdoc id = dev-s435
 # sent_id = dev-s435
+# parallel_id = jagsd/dev435
 # text = 1928年10月から1929年11月にかけて初代駐トルコ大使である小幡酉吉の帰朝にともない臨時代理大使を務め、この間に参事官へと昇格した。
 1	1928	1928	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九二八,1928,1928,イチキューニハチ,,,イチキュウニハチ,イチキュウニハチネン,1928年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチキュウニハチネン,1928年
@@ -12394,6 +12826,7 @@
 
 # newdoc id = dev-s436
 # sent_id = dev-s436
+# parallel_id = jagsd/dev436
 # text = 彼女たちは「負け犬」を自称しながら、その実オタクを恋愛対象にしようとせずヒエラルキーの下位におき、自己の精神的安寧を得ているに過ぎず、そのオタクを否定する価値観も「恋愛資本主義」に洗脳されているに過ぎないと主張した。
 1	彼女	彼女	PRON	代名詞	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=カノジョ,彼女,彼女,彼女,カノジョ,,,カノジョ,カノジョタチ,彼女達
 2	たち	達	NOUN	接尾辞-名詞的-一般	_	65	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=タチ,達,たち,たち,タチ,,,タチ,カノジョタチ,彼女達
@@ -12466,6 +12899,7 @@
 
 # newdoc id = dev-s437
 # sent_id = dev-s437
+# parallel_id = jagsd/dev437
 # text = 民主党公約があてにならないのはまだある。
 1	民主	民主	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ミンシュ,民主,民主,民主,ミンシュ,,,ミンシュ,ミンシュトウコウヤク,民主党公約
 2	党	党	NOUN	接尾辞-名詞的-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウ,党,党,党,トー,,,トウ,ミンシュトウコウヤク,民主党公約
@@ -12483,6 +12917,7 @@
 
 # newdoc id = dev-s438
 # sent_id = dev-s438
+# parallel_id = jagsd/dev438
 # text = だが、最後は仲間達の願いを受けて復活したメビウスのメビュームシュートとウルトラ兄弟の合体光線を受けて再び消滅した。
 1	だ	だ	CCONJ	助動詞-助動詞-ダ	_	30	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダガ,だが
 2	が	が	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ダガ,だが
@@ -12520,6 +12955,7 @@
 
 # newdoc id = dev-s439
 # sent_id = dev-s439
+# parallel_id = jagsd/dev439
 # text = しかしプラセボ効果は,患者を騙すからこそ生まれる効果です。
 1	しかし	然し	CCONJ	接続詞	_	12	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	プラセボ	プラシーボ	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=プラシーボ,プラシーボ,プラセボ,プラセボ,プラセボ,,,プラセボ,プラセボコウカ,プラセボ効果
@@ -12538,6 +12974,7 @@
 
 # newdoc id = dev-s440
 # sent_id = dev-s440
+# parallel_id = jagsd/dev440
 # text = 遊学館は県予選会後に3年の亀樋哲生、吉田圭佑の両選手ら主力3人が故障して欠場した。
 1	遊学	遊学	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ユウガク,遊学,遊学,遊学,ユーガク,,,ユウガク,ユウガクカン,遊学館
 2	館	館	NOUN	接尾辞-名詞的-一般	_	28	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=カン,館,館,館,カン,,,カン,ユウガクカン,遊学館
@@ -12573,6 +13010,7 @@
 
 # newdoc id = dev-s441
 # sent_id = dev-s441
+# parallel_id = jagsd/dev441
 # text = 属品として負紐付きの収容嚢が存在し、行軍時などには狙撃眼鏡を銃から外しこれに収容した。
 1	属品	属品	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゾクヒン,属品,属品,属品,ゾクヒン,,,ゾクヒン,ゾクヒン,属品
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,トシテ,として
@@ -12607,6 +13045,7 @@
 
 # newdoc id = dev-s442
 # sent_id = dev-s442
+# parallel_id = jagsd/dev442
 # text = 宇高航路においては、初の車載客船でもあった。
 1	宇高	宇高	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ウコウ,宇高,宇高,宇高,ウコー,,,ウコウ,ウコウコウロ,宇高航路
 2	航路	航路	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウロ,航路,航路,航路,コーロ,,,コウロ,ウコウコウロ,宇高航路
@@ -12627,6 +13066,7 @@
 
 # newdoc id = dev-s443
 # sent_id = dev-s443
+# parallel_id = jagsd/dev443
 # text = 車の販売、板金、塗装等を行っています。
 1	車	車	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クルマ,車,車,車,クルマ,,,クルマ,クルマ,車
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12645,6 +13085,7 @@
 
 # newdoc id = dev-s444
 # sent_id = dev-s444
+# parallel_id = jagsd/dev444
 # text = 柱の円周は、大人5人が手を伸ばして抱えても届かないくらいの大きさである。
 1	柱	柱	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハシラ,柱,柱,柱,ハシラ,,,ハシラ,ハシラ,柱
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12674,6 +13115,7 @@
 
 # newdoc id = dev-s445
 # sent_id = dev-s445
+# parallel_id = jagsd/dev445
 # text = 有名な先生方が講師として来られています。
 1	有名	有名	ADJ	形状詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ユウメイ,有名,有名,有名,ユーメー,,,ユウメイ,ユウメイ,有名
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -12693,6 +13135,7 @@
 
 # newdoc id = dev-s446
 # sent_id = dev-s446
+# parallel_id = jagsd/dev446
 # text = 悲観的になるとは,階級的意識がないことであるが,本来敵であるものを味方と思った時,その失望が悲観的にさせる。
 1	悲観	悲観	NOUN	名詞-普通名詞-サ変可能	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ヒカン,悲観,悲観,悲観,ヒカン,,,ヒカン,ヒカンテキ,悲観的
 2	的	的	PART	接尾辞-形状詞的	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=テキ,的,的,的,テキ,,,テキ,ヒカンテキ,悲観的
@@ -12735,6 +13178,7 @@
 
 # newdoc id = dev-s447
 # sent_id = dev-s447
+# parallel_id = jagsd/dev447
 # text = 好物はマシュマロ。
 1	好物	好物	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウブツ,好物,好物,好物,コーブツ,,,コウブツ,コウブツ,好物
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12743,6 +13187,7 @@
 
 # newdoc id = dev-s448
 # sent_id = dev-s448
+# parallel_id = jagsd/dev448
 # text = 私は,幸福の施設しか知らなくて恐縮ですが,安心して過ごせる所だと思う。
 1	私	私	PRON	代名詞	_	22	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12770,6 +13215,7 @@
 
 # newdoc id = dev-s449
 # sent_id = dev-s449
+# parallel_id = jagsd/dev449
 # text = こじんまりした、アットホームな良い雰囲気で食事が出来ます。
 1	こじんまり	小ぢんまり	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=コヂンマリ,小ぢんまり,こじんまり,こじんまり,コジンマリ,,,コヂンマリ,コヂンマリスル,小ぢんまりする
 2	し	為る	AUX	動詞-非自立可能-サ行変格	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,コヂンマリスル,小ぢんまりする
@@ -12789,6 +13235,7 @@
 
 # newdoc id = dev-s450
 # sent_id = dev-s450
+# parallel_id = jagsd/dev450
 # text = クアラルンプールで開催されるマラソンはこのほか「KLマラソン」など、複数の大会がある。
 1	クアラルンプール	クアラルンプール	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=クアラルンプール,クアラ・ルンプール,クアラルンプール,クアラルンプール,クアラルンプール,,,クアラルンプール,クアラルンプール,クアラルンプール
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -12814,6 +13261,7 @@
 
 # newdoc id = dev-s451
 # sent_id = dev-s451
+# parallel_id = jagsd/dev451
 # text = SF作品などで、宇宙船の航行が著しく困難な空間に「サルガッソ」の名が冠されることがある。
 1	SF	SF	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エスエフ,ＳＦ,SF,SF,エスエフ,,,エスエフ,エスエフサクヒン,SF作品
 2	作品	作品	NOUN	名詞-普通名詞-一般	_	22	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サクヒン,作品,作品,作品,サクヒン,,,サクヒン,エスエフサクヒン,SF作品
@@ -12845,6 +13293,7 @@
 
 # newdoc id = dev-s452
 # sent_id = dev-s452
+# parallel_id = jagsd/dev452
 # text = 英語の公用語化云々よりも、まずは国際感覚を身につける社員教育の方が優先すべきだろう。
 1	英語	英語	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エイゴ,英語,英語,英語,エーゴ,,,エイゴ,エイゴ,英語
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12876,6 +13325,7 @@
 
 # newdoc id = dev-s453
 # sent_id = dev-s453
+# parallel_id = jagsd/dev453
 # text = 本作より昔の話である『ドラゴンクエストIII』の時代では魔物に滅ぼされておらず活気のある町として存在していた。
 1	本作	本作	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホンサク,本作,本作,本作,ホンサク,,,ホンサク,ホンサク,本作
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -12916,6 +13366,7 @@
 
 # newdoc id = dev-s454
 # sent_id = dev-s454
+# parallel_id = jagsd/dev454
 # text = 2009年11月28日、サードアルバム、『HellChose Me 』のレコーディングを終える。
 1	2009	2009	NUM	名詞-数詞	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ九,2009,2009,ニゼロゼロキュー,,,ニゼロゼロキュウ,ニゼロゼロキュウネン,2009年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロキュウネン,2009年
@@ -12940,6 +13391,7 @@
 
 # newdoc id = dev-s455
 # sent_id = dev-s455
+# parallel_id = jagsd/dev455
 # text = 今年7月から、宝塚歌劇の専門チャンネル「タカラヅカ・スカイ・ステージ」の案内役スカイ・フェアリーズを務めている。
 1	今年	今年	NOUN	名詞-普通名詞-副詞可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コトシ,今年,今年,今年,コトシ,,,コトシ,コトシ,今年
 2	7	7	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=シチ,七,7,7,シチ,,,シチ,シチガツ,7月
@@ -12972,6 +13424,7 @@
 
 # newdoc id = dev-s456
 # sent_id = dev-s456
+# parallel_id = jagsd/dev456
 # text = 取締機によって撮影されると、数日から遅くとも30日以内に警察から当該車両の所有者に出頭通知が送付される。
 1	取締	取り締まり	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トリシマリ,取り締まり,取締,取締,トリシマリ,,,トリシマリ,トリシマリキ,取り締まり機
 2	機	機	NOUN	名詞-普通名詞-助数詞可能	_	6	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キ,機,機,機,キ,,,キ,トリシマリキ,取り締まり機
@@ -13010,6 +13463,7 @@
 
 # newdoc id = dev-s457
 # sent_id = dev-s457
+# parallel_id = jagsd/dev457
 # text = 享年84。
 1	享年	享年	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウネン,享年,享年,享年,キョーネン,,,キョウネン,キョウネン,享年
 2	84	84	NUM	名詞-数詞	_	0	root	_	BunsetuBILabel=I|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ハチ,八四,84,84,ハチヨン,,,ハチヨン,ハチヨン,84
@@ -13017,6 +13471,7 @@
 
 # newdoc id = dev-s458
 # sent_id = dev-s458
+# parallel_id = jagsd/dev458
 # text = 当初は熊田の傍若無人ぶりにブーイングの嵐だった観衆も、「まともに戦うのなら」という条件付きで熊田応援に回り、場内は熊田コールと仲本コールに二分された。
 1	当初	当初	NOUN	名詞-普通名詞-副詞可能	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -13068,6 +13523,7 @@
 
 # newdoc id = dev-s459
 # sent_id = dev-s459
+# parallel_id = jagsd/dev459
 # text = 脳梗塞の症状で入院していた60歳代の男性が、食事で出されたおかゆを喉に詰まらせた。
 1	脳	脳	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ノウ,脳,脳,脳,ノー,,,ノウ,ノウコウソク,脳梗塞
 2	梗塞	梗塞	NOUN	名詞-普通名詞-サ変可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウソク,梗塞,梗塞,梗塞,コーソク,,,コウソク,ノウコウソク,脳梗塞
@@ -13103,6 +13559,7 @@
 
 # newdoc id = dev-s460
 # sent_id = dev-s460
+# parallel_id = jagsd/dev460
 # text = 幼いゆえか、大人っぽさに憧れている。
 1	幼い	幼い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=オサナイ,幼い,幼い,幼い,オサナイ,,,オサナイ,オサナイ,幼い
 2	ゆえ	故	NOUN	名詞-普通名詞-副詞可能	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ユエ,故,ゆえ,ゆえ,ユエ,,,ユエ,ユエ,故
@@ -13119,6 +13576,7 @@
 
 # newdoc id = dev-s461
 # sent_id = dev-s461
+# parallel_id = jagsd/dev461
 # text = ネタ番組のように、3段オチを考えるコーナーではない。
 1	ネタ	ねた	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ネタ,ねた,ネタ,ネタ,ネタ,,,ネタ,ネタバングミ,ねた番組
 2	番組	番組	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バングミ,番組,番組,番組,バングミ,,,バングミ,ネタバングミ,ねた番組
@@ -13139,6 +13597,7 @@
 
 # newdoc id = dev-s462
 # sent_id = dev-s462
+# parallel_id = jagsd/dev462
 # text = バター珈琲の味が好きな方にはお薦めだが、外連味の無い、王道の珈琲を求める方には向かない。
 1	バター	バター	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バター,バター,バター,バター,バター,,,バター,バターコーヒー,バターコーヒー
 2	珈琲	コーヒー	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コーヒー,コーヒー,珈琲,珈琲,コーヒー,,,コーヒー,バターコーヒー,バターコーヒー
@@ -13174,6 +13633,7 @@
 
 # newdoc id = dev-s463
 # sent_id = dev-s463
+# parallel_id = jagsd/dev463
 # text = 対称性を評価するパターン、生え際を評価するパターン、鼻や口の大きさを評価するパターンなどがある。
 1	対称	対称	NOUN	名詞-普通名詞-形状詞可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タイショウ,対称,対称,対称,タイショー,,,タイショウ,タイショウセイ,対称性
 2	性	性	NOUN	接尾辞-名詞的-一般	_	4	obj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイ,性,性,性,セー,,,セイ,タイショウセイ,対称性
@@ -13205,6 +13665,7 @@
 
 # newdoc id = dev-s465
 # sent_id = dev-s465
+# parallel_id = jagsd/dev465
 # text = ハムスターの診察をしてくれる病院は少なくとても助かりました。
 1	ハムスター	ハムスター	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハムスター,ハムスター,ハムスター,ハムスター,ハムスター,,,ハムスター,ハムスター,ハムスター
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13224,6 +13685,7 @@
 
 # newdoc id = dev-s466
 # sent_id = dev-s466
+# parallel_id = jagsd/dev466
 # text = 休養を挟んで京成杯オータムハンデキャップに出走したが、5着に敗れた。
 1	休養	休養	NOUN	名詞-普通名詞-サ変可能	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キュウヨウ,休養,休養,休養,キューヨー,,,キュウヨウ,キュウヨウ,休養
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -13248,6 +13710,7 @@
 
 # newdoc id = dev-s467
 # sent_id = dev-s467
+# parallel_id = jagsd/dev467
 # text = ファイブブラックの個人武器。
 1	ファイブ	ファイブ	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ファイブ,ファイブ,ファイブ,ファイブ,ファイブ,,,ファイブ,ファイブブラック,ファイブブラック
 2	ブラック	ブラック	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ブラック,ブラック,ブラック,ブラック,ブラック,,,ブラック,ファイブブラック,ファイブブラック
@@ -13258,6 +13721,7 @@
 
 # newdoc id = dev-s468
 # sent_id = dev-s468
+# parallel_id = jagsd/dev468
 # text = 朝まで飲み会コースというのがあり、4品で1500円くらいのようですよ。
 1	朝	朝	NOUN	名詞-普通名詞-副詞可能	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アサ,朝,朝,朝,アサ,,,アサ,アサ,朝
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -13283,6 +13747,7 @@
 
 # newdoc id = dev-s469
 # sent_id = dev-s469
+# parallel_id = jagsd/dev469
 # text = 同国の国営テレビは、ムバラク氏が公金横領や反体制デモ参加者殺害などの疑いで検察当局の聴取を受けている最中に心臓発作で倒れ、入院先で集中治療を受けていると報じた。
 1	同国	同国	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウコク,同国,同国,同国,ドーコク,,,ドウコク,ドウコク,同国
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13337,6 +13802,7 @@
 
 # newdoc id = dev-s470
 # sent_id = dev-s470
+# parallel_id = jagsd/dev470
 # text = 通称・但馬、和泉、又左衛門。
 1	通称	通称	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ツウショウ,通称,通称,通称,ツーショー,,,ツウショウ,ツウショウ,通称
 2	・	・	SYM	補助記号-一般	_	1	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,,・
@@ -13349,6 +13815,7 @@
 
 # newdoc id = dev-s471
 # sent_id = dev-s471
+# parallel_id = jagsd/dev471
 # text = 真っ黒のタレだけど美味しいよ。
 1	真っ黒	真っ黒	ADJ	形状詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=マックロ,真っ黒,真っ黒,真っ黒,マックロ,,,マックロ,マックロ,真っ黒
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13361,6 +13828,7 @@
 
 # newdoc id = dev-s472
 # sent_id = dev-s472
+# parallel_id = jagsd/dev472
 # text = かつて虐めにあっていた大和の中学時代の同級生。
 1	かつて	嘗て	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=カツテ,嘗て,かつて,かつて,カツテ,,,カツテ,カツテ,嘗て
 2	虐め	苛め	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イジメ,苛め,虐め,虐め,イジメ,,,イジメ,イジメ,苛め
@@ -13380,6 +13848,7 @@
 
 # newdoc id = dev-s473
 # sent_id = dev-s473
+# parallel_id = jagsd/dev473
 # text = すると店内がかわいくて気に入りパ—マとカットをしてもらいました。
 1	する	為る	CCONJ	動詞-非自立可能-サ行変格	_	14	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,する,する,スル,,,スル,スルト,すると
 2	と	と	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,スルト,すると
@@ -13403,6 +13872,7 @@
 
 # newdoc id = dev-s474
 # sent_id = dev-s474
+# parallel_id = jagsd/dev474
 # text = 2010年10月17日にインディアナ州で前立腺がんで亡くなった。
 1	2010	2010	NUM	名詞-数詞	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロ一ゼロ,2010,2010,ニゼロイチゼロ,,,ニゼロイチゼロ,ニゼロイチゼロネン,2010年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロイチゼロネン,2010年
@@ -13424,6 +13894,7 @@
 
 # newdoc id = dev-s475
 # sent_id = dev-s475
+# parallel_id = jagsd/dev475
 # text = 劉裕の異母弟にあたる。
 1	劉裕	劉裕	PROPN	名詞-固有名詞-人名-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=リュウユウ,リュウユウ,劉裕,劉裕,リューユー,,,リュウユウ,リュウユウ,劉裕
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13435,6 +13906,7 @@
 
 # newdoc id = dev-s476
 # sent_id = dev-s476
+# parallel_id = jagsd/dev476
 # text = 看護師不足が問題となる中、高梁市が看護師を目指す学生を対象にした看護師養成奨学金制度をつくり、4月から奨学生の募集を始める。
 1	看護	看護	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カンゴ,看護,看護,看護,カンゴ,,,カンゴ,カンゴシブソク,看護師不足
 2	師	師	NOUN	接尾辞-名詞的-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シ,師,師,師,シ,,,シ,カンゴシブソク,看護師不足
@@ -13480,6 +13952,7 @@
 
 # newdoc id = dev-s477
 # sent_id = dev-s477
+# parallel_id = jagsd/dev477
 # text = 1821年から1867年までの長きに亘ってモスクワ府主教位にあった。
 1	1821	1821	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一八二一,1821,1821,イチハチニイチ,,,イチハチニイチ,イチハチニイチネン,1821年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチハチニイチネン,1821年
@@ -13503,6 +13976,7 @@
 
 # newdoc id = dev-s478
 # sent_id = dev-s478
+# parallel_id = jagsd/dev478
 # text = でも重症じゃないので絶対に治ると信じて治療に専念し、きれいな女性になりたいとの想いを込め、決断しました。
 1	で	で	CCONJ	助詞-格助詞	_	31	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デモ,でも
 2	も	も	ADP	助詞-係助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,デモ,でも
@@ -13542,6 +14016,7 @@
 
 # newdoc id = dev-s479
 # sent_id = dev-s479
+# parallel_id = jagsd/dev479
 # text = この風景を学生が見たら大喜びをするに違いない。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	風景	風景	NOUN	名詞-普通名詞-一般	_	6	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フウケイ,風景,風景,風景,フーケー,,,フウケイ,フウケイ,風景
@@ -13560,6 +14035,7 @@
 
 # newdoc id = dev-s480
 # sent_id = dev-s480
+# parallel_id = jagsd/dev480
 # text = 現在の書店「丸善」だ。
 1	現在	現在	NOUN	名詞-普通名詞-副詞可能	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13572,6 +14048,7 @@
 
 # newdoc id = dev-s481
 # sent_id = dev-s481
+# parallel_id = jagsd/dev481
 # text = ここの居酒屋のメニューで目を引いたのは、やっぱりコラーゲン鍋でしょ!
 1	ここ	此処	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13594,6 +14071,7 @@
 
 # newdoc id = dev-s482
 # sent_id = dev-s482
+# parallel_id = jagsd/dev482
 # text = 大きな一つ目に小さな胴体、細い手足、とんがり帽子という異形だが何処かコミカルにも見える姿をとる。
 1	大きな	大きな	ADJ	連体詞	_	4	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=オオキナ,大きな,大きな,大きな,オーキナ,,,オオキナ,オオキナ,大きな
 2	一	一	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ヒト,一,一,一,ヒト,,,ヒト,ヒトツ,一つ
@@ -13626,6 +14104,7 @@
 
 # newdoc id = dev-s483
 # sent_id = dev-s483
+# parallel_id = jagsd/dev483
 # text = ここから、単なる文字列よりも高機能なクラスなどをロープと呼ぶことがある。
 1	ここ	此処	PRON	代名詞	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ココ,此処,ここ,ここ,ココ,,,ココ,ココ,此処
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -13651,6 +14130,7 @@
 
 # newdoc id = dev-s484
 # sent_id = dev-s484
+# parallel_id = jagsd/dev484
 # text = 柔道人生は終わるまで安心できない。
 1	柔道	柔道	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジュウドウ,柔道,柔道,柔道,ジュードー,,,ジュウドウ,ジュウドウジンセイ,柔道人生
 2	人生	人生	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジンセイ,人生,人生,人生,ジンセー,,,ジンセイ,ジュウドウジンセイ,柔道人生
@@ -13664,6 +14144,7 @@
 
 # newdoc id = dev-s485
 # sent_id = dev-s485
+# parallel_id = jagsd/dev485
 # text = 雪に足をとられないようにするために足裏に取り付けられるミニスキー。
 1	雪	雪	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ユキ,雪,雪,雪,ユキ,,,ユキ,ユキ,雪
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -13687,6 +14168,7 @@
 
 # newdoc id = dev-s486
 # sent_id = dev-s486
+# parallel_id = jagsd/dev486
 # text = 作品にはオペラ、バレエ、映画音楽、劇場音楽があり、リトアニア・ソビエト社会主義共和国の国歌も作曲している。
 1	作品	作品	NOUN	名詞-普通名詞-一般	_	14	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サクヒン,作品,作品,作品,サクヒン,,,サクヒン,サクヒン,作品
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -13721,6 +14203,7 @@
 
 # newdoc id = dev-s487
 # sent_id = dev-s487
+# parallel_id = jagsd/dev487
 # text = 静岡県出身。
 1	静岡	静岡	PROPN	名詞-固有名詞-地名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シズオカ,シズオカ,静岡,静岡,シズオカ,,,シズオカ,シズオカケンシュッシン,静岡県出身
 2	県	県	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケン,県,県,県,ケン,,,ケン,シズオカケンシュッシン,静岡県出身
@@ -13729,6 +14212,7 @@
 
 # newdoc id = dev-s488
 # sent_id = dev-s488
+# parallel_id = jagsd/dev488
 # text = あと、びっくりなのが、玄関前にペンギンが3羽。
 1	あと	後	ADV	名詞-普通名詞-副詞可能	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=アト,後,あと,あと,アト,,,アト,アト,後
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -13748,6 +14232,7 @@
 
 # newdoc id = dev-s489
 # sent_id = dev-s489
+# parallel_id = jagsd/dev489
 # text = 鉄郎の同僚でドーテーズの初期メンバー。
 1	鉄郎	鉄郎	PROPN	名詞-固有名詞-人名-名	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-名|SpaceAfter=No|UnidicInfo=テツオ,テツオ,鉄郎,鉄郎,テツオ,,,テツオ,テツオ,鉄郎
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13761,6 +14246,7 @@
 
 # newdoc id = dev-s490
 # sent_id = dev-s490
+# parallel_id = jagsd/dev490
 # text = X線新星の特徴である、数ヶ月かけて暗くなる性質と一致している。
 1	X	X	NOUN	記号-文字	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エックス,Ｘ,X,X,エックス,,,エックス,エックスセンシンセイ,X線新星
 2	線	線	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セン,線,線,線,セン,,,セン,エックスセンシンセイ,X線新星
@@ -13786,6 +14272,7 @@
 
 # newdoc id = dev-s491
 # sent_id = dev-s491
+# parallel_id = jagsd/dev491
 # text = 地区予選で敗者復活戦に回った雪辱を果たせるか。
 1	地区	地区	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チク,地区,地区,地区,チク,,,チク,チクヨセン,地区予選
 2	予選	予選	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨセン,予選,予選,予選,ヨセン,,,ヨセン,チクヨセン,地区予選
@@ -13804,6 +14291,7 @@
 
 # newdoc id = dev-s492
 # sent_id = dev-s492
+# parallel_id = jagsd/dev492
 # text = ノルウェーの劇作家ヘンリック・イプセンの劇詩『ペール・ギュント』の登場人物に因んで命名された。
 1	ノルウェー	ノルウェー	PROPN	名詞-固有名詞-地名-国	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=ノルウェー,ノルウェー,ノルウェー,ノルウェー,ノルウェー,,,ノルウェー,ノルウェー,ノルウェー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13833,6 +14321,7 @@
 
 # newdoc id = dev-s493
 # sent_id = dev-s493
+# parallel_id = jagsd/dev493
 # text = 3月20日に発売開始。
 1	3	3	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=サン,三,3,3,サン,,,サン,サンガツ,3月
 2	月	月	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ガツ,月,月,月,ガツ,,,ガツ,サンガツ,3月
@@ -13845,6 +14334,7 @@
 
 # newdoc id = dev-s494
 # sent_id = dev-s494
+# parallel_id = jagsd/dev494
 # text = 今上大岡に住んでいて、毎週行っています。
 1	今	今	ADV	名詞-普通名詞-副詞可能	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イマ,今,今,今,イマ,,,イマ,イマ,今
 2	上大岡	上大岡	PROPN	名詞-固有名詞-地名-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=カミオオオカ,カミオオオカ,上大岡,上大岡,カミオーオカ,,,カミオオオカ,カミオオオカ,上大岡
@@ -13863,6 +14353,7 @@
 
 # newdoc id = dev-s495
 # sent_id = dev-s495
+# parallel_id = jagsd/dev495
 # text = 千月学園に通いつつ弥勒院をサポートする有能な助手ではあるが、謎も多い不思議な少女。
 1	千月	千月	PROPN	名詞-固有名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=センゲツ,千月,千月,千月,センゲツ,,,センゲツ,センゲツガクエン,千月学園
 2	学園	学園	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ガクエン,学園,学園,学園,ガクエン,,,ガクエン,センゲツガクエン,千月学園
@@ -13891,6 +14382,7 @@
 
 # newdoc id = dev-s496
 # sent_id = dev-s496
+# parallel_id = jagsd/dev496
 # text = 旧松山藩領東部に当たる西条6万8600石は、伊勢国神戸藩主一柳直盛に与えられたが、加増のうえ転封することとなった直盛は、采地に赴く途中の大坂で没した。
 1	旧	旧	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キュウ,旧,旧,旧,キュー,,,キュウ,キュウマツヤマハンリョウトウブ,旧松山藩領東部
 2	松山	松山	PROPN	名詞-固有名詞-地名-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マツヤマ,マツヤマ,松山,松山,マツヤマ,,,マツヤマ,キュウマツヤマハンリョウトウブ,旧松山藩領東部
@@ -13942,6 +14434,7 @@
 
 # newdoc id = dev-s497
 # sent_id = dev-s497
+# parallel_id = jagsd/dev497
 # text = 霊芝には毛細血管の血液循環を促進する働きがあります。
 1	霊芝	霊芝	NOUN	名詞-普通名詞-一般	_	14	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=レイシ,霊芝,霊芝,霊芝,レーシ,,,レイシ,レイシ,霊芝
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -13962,6 +14455,7 @@
 
 # newdoc id = dev-s498
 # sent_id = dev-s498
+# parallel_id = jagsd/dev498
 # text = 『第2次OG』でコウタと共に帰還し、海上でヒリュウ改を襲撃したイグニスを撃破後に鋼龍戦隊に合流。
 1	『	『	PUNCT	補助記号-括弧開	_	6	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
 2	第	第	NOUN	接頭辞	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ダイ,第,第,第,ダイ,,,ダイ,ダイニジオージー,第2次OG
@@ -13999,6 +14493,7 @@
 
 # newdoc id = dev-s499
 # sent_id = dev-s499
+# parallel_id = jagsd/dev499
 # text = 2位の天草本渡クラブと3位の菊池クラブは10月に宮崎県で行われる九州大会に出場する。
 1	2	2	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニ,二,2,2,ニ,,,ニ,ニイ,2位
 2	位	位	NOUN	接尾辞-名詞的-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イ,位,位,位,イ,,,イ,ニイ,2位
@@ -14030,6 +14525,7 @@
 
 # newdoc id = dev-s500
 # sent_id = dev-s500
+# parallel_id = jagsd/dev500
 # text = 財務相のヘルムート・シュミットに連邦首相の座を譲った。
 1	財務	財務	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ザイム,財務,財務,財務,ザイム,,,ザイム,ザイムショウ,財務相
 2	相	相	NOUN	接尾辞-名詞的-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショウ,相,相,相,ショー,,,ショウ,ザイムショウ,財務相
@@ -14049,6 +14545,7 @@
 
 # newdoc id = dev-s501
 # sent_id = dev-s501
+# parallel_id = jagsd/dev501
 # text = 2008年4月6日午前11時に子供が生まれるとします。
 1	2008	2008	NUM	名詞-数詞	_	9	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ八,2008,2008,ニゼロゼロハチ,,,ニゼロゼロハチ,ニゼロゼロハチネン,2008年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	9	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロハチネン,2008年
@@ -14070,6 +14567,7 @@
 
 # newdoc id = dev-s502
 # sent_id = dev-s502
+# parallel_id = jagsd/dev502
 # text = スターフェリーやヨーマティフェリーが創業すると、非常に重要であることを証明することになった。
 1	スター	スター	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=スター,スター,スター,スター,スター,,,スター,スターフェリー,スターフェリー
 2	フェリー	フェリー	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=フェリー,フェリー,フェリー,フェリー,フェリー,,,フェリー,スターフェリー,スターフェリー
@@ -14098,6 +14596,7 @@
 
 # newdoc id = dev-s503
 # sent_id = dev-s503
+# parallel_id = jagsd/dev503
 # text = 横柄な女医の婆さんといい加減な受付。
 1	横柄	横柄	ADJ	形状詞-一般	_	6	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=オウヘイ,横柄,横柄,横柄,オーヘー,,,オウヘイ,オウヘイ,横柄
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -14114,6 +14613,7 @@
 
 # newdoc id = dev-s504
 # sent_id = dev-s504
+# parallel_id = jagsd/dev504
 # text = この荻野氏,自らクラシカルホメオパシー京都という団体を主宰し,ホメオパシー講座を開催しています。
 1	この	此の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	荻野	荻野	PROPN	名詞-固有名詞-人名-姓	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=オギノ,オギノ,荻野,荻野,オギノ,,,オギノ,オギノシ,荻野氏
@@ -14142,6 +14642,7 @@
 
 # newdoc id = dev-s505
 # sent_id = dev-s505
+# parallel_id = jagsd/dev505
 # text = メソポタミア南部は文字による記録が残される最初期からシュメール語とセム語のバイリンガル地帯であった。
 1	メソポタミア	メソポタミア	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=メソポタミア,メソポタミア,メソポタミア,メソポタミア,メソポタミア,,,メソポタミア,メソポタミアナンブ,メソポタミア南部
 2	南部	南部	NOUN	名詞-普通名詞-一般	_	21	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナンブ,南部,南部,南部,ナンブ,,,ナンブ,メソポタミアナンブ,メソポタミア南部
@@ -14171,6 +14672,7 @@
 
 # newdoc id = dev-s506
 # sent_id = dev-s506
+# parallel_id = jagsd/dev506
 # text = また日本語学者の寺村秀夫も自著では「名容詞」という用語を用いている。
 1	また	又	CCONJ	接続詞	_	21	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	日本	日本	PROPN	名詞-固有名詞-地名-国	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニッポン,日本,日本,日本,ニホン,,,ニホン,ニホンゴガクシャ,日本語学者
@@ -14199,6 +14701,7 @@
 
 # newdoc id = dev-s507
 # sent_id = dev-s507
+# parallel_id = jagsd/dev507
 # text = お風呂大きくはないけれどお湯はきれい。
 1	お	御	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オフロ,御風呂
 2	風呂	風呂	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フロ,風呂,風呂,風呂,フロ,,,フロ,オフロ,御風呂
@@ -14214,6 +14717,7 @@
 
 # newdoc id = dev-s508
 # sent_id = dev-s508
+# parallel_id = jagsd/dev508
 # text = 新生闇軍団頭領。
 1	新生	新生	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンセイ,新生,新生,新生,シンセー,,,シンセイ,シンセイヤミグンダントウリョウ,新生闇軍団頭領
 2	闇	闇	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヤミ,闇,闇,闇,ヤミ,,,ヤミ,シンセイヤミグンダントウリョウ,新生闇軍団頭領
@@ -14223,6 +14727,7 @@
 
 # newdoc id = dev-s509
 # sent_id = dev-s509
+# parallel_id = jagsd/dev509
 # text = 当初の説明と実際の施設の状態が違うという点も,川島町の住民の証言とよく似ています。
 1	当初	当初	NOUN	名詞-普通名詞-副詞可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -14256,6 +14761,7 @@
 
 # newdoc id = dev-s510
 # sent_id = dev-s510
+# parallel_id = jagsd/dev510
 # text = それでいてこの対応である。
 1	それ	其れ	PRON	代名詞	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -14269,6 +14775,7 @@
 
 # newdoc id = dev-s511
 # sent_id = dev-s511
+# parallel_id = jagsd/dev511
 # text = 児童生徒が犠牲になる事態も多く、同市にある京田幼児園では園舎が倒壊し園児3名が圧死、園児14名と保育士1名が生き埋めとなった。
 1	児童	児童	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジドウ,児童,児童,児童,ジドー,,,ジドウ,ジドウセイト,児童生徒
 2	生徒	生徒	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイト,生徒,生徒,生徒,セート,,,セイト,ジドウセイト,児童生徒

--- a/ja_gsd-ud-test.conllu
+++ b/ja_gsd-ud-test.conllu
@@ -1,5 +1,6 @@
 # newdoc id = test-s1
 # sent_id = test-s1
+# parallel_id = jagsd/test1
 # text = これに不快感を示す住民はいましたが,現在,表立って反対や抗議の声を挙げている住民はいないようです。
 1	これ	此れ	PRON	代名詞	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -37,6 +38,7 @@
 
 # newdoc id = test-s2
 # sent_id = test-s2
+# parallel_id = jagsd/test2
 # text = 幸福の科学側からは,特にどうしてほしいという要望はいただいていません。
 1	幸福	幸福	NOUN	名詞-普通名詞-形状詞可能	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウフク,幸福,幸福,幸福,コーフク,,,コウフク,コウフクノカガクガワ,幸福の科学側
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,コウフクノカガクガワ,幸福の科学側
@@ -63,6 +65,7 @@
 
 # newdoc id = test-s3
 # sent_id = test-s3
+# parallel_id = jagsd/test3
 # text = 星取り参加は当然とされ,不参加は白眼視される。
 1	星取り	星取り	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホシトリ,星取り,星取り,星取り,ホシトリ,,,ホシトリ,ホシトリサンカ,星取り参加
 2	参加	参加	NOUN	名詞-普通名詞-サ変可能	_	4	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サンカ,参加,参加,参加,サンカ,,,サンカ,ホシトリサンカ,星取り参加
@@ -83,6 +86,7 @@
 
 # newdoc id = test-s4
 # sent_id = test-s4
+# parallel_id = jagsd/test4
 # text = 室長の対応には終始誠実さが感じられた。
 1	室長	室長	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シツチョウ,室長,室長,室長,シツチョー,,,シツチョウ,シツチョウ,室長
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -100,6 +104,7 @@
 
 # newdoc id = test-s5
 # sent_id = test-s5
+# parallel_id = jagsd/test5
 # text = 多くの女性が生理のことで悩んでいます。
 1	多く	多く	NOUN	名詞-普通名詞-副詞可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オオク,多く,多く,多く,オーク,,,オオク,オオク,多く
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -117,6 +122,7 @@
 
 # newdoc id = test-s6
 # sent_id = test-s6
+# parallel_id = jagsd/test6
 # text = 先生の理想は限りなく高い。
 1	先生	先生	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センセイ,先生,先生,先生,センセー,,,センセイ,センセイ,先生
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -128,6 +134,7 @@
 
 # newdoc id = test-s7
 # sent_id = test-s7
+# parallel_id = jagsd/test7
 # text = それは兎も角,私も明日の社説を楽しみにしております。
 1	それ	其れ	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレ,其れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -149,6 +156,7 @@
 
 # newdoc id = test-s8
 # sent_id = test-s8
+# parallel_id = jagsd/test8
 # text = そうだったらいいなあとは思いますが,日本学術会議の会長談話について“当会では,標記の件について,以下のように考えます。”
 1	そう	そう	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ソウ,そう,そう,そう,ソー,,,ソウ,ソウ,そう
 2	だっ	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,だっ,だ,ダッ,,,ダ,ダ,だ
@@ -193,6 +201,7 @@
 
 # newdoc id = test-s9
 # sent_id = test-s9
+# parallel_id = jagsd/test9
 # text = 教団にとっては存続が厳しくなると思う。
 1	教団	教団	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウダン,教団,教団,教団,キョーダン,,,キョウダン,キョウダン,教団
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニトッテ,にとって
@@ -209,6 +218,7 @@
 
 # newdoc id = test-s10
 # sent_id = test-s10
+# parallel_id = jagsd/test10
 # text = しかし強制していなくても問題です
 1	しかし	然し	CCONJ	接続詞	_	9	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	強制	強制	VERB	名詞-普通名詞-サ変可能	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=キョウセイ,強制,強制,強制,キョーセー,,,キョウセイ,キョウセイスル,強制する
@@ -223,6 +233,7 @@
 
 # newdoc id = test-s11
 # sent_id = test-s11
+# parallel_id = jagsd/test11
 # text = 民族派のみなさんにとって陛下はいちばん大切な方ですから,その霊言について“あり得ない”という前提でお話をされる。
 1	民族	民族	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ミンゾク,民族,民族,民族,ミンゾク,,,ミンゾク,ミンゾクハ,民族派
 2	派	派	NOUN	接尾辞-名詞的-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハ,派,派,派,ハ,,,ハ,ミンゾクハ,民族派
@@ -264,6 +275,7 @@
 
 # newdoc id = test-s12
 # sent_id = test-s12
+# parallel_id = jagsd/test12
 # text = 新しい産業構造を作らなければいけない。
 1	新しい	新しい	ADJ	形容詞-一般-形容詞	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=アタラシイ,新しい,新しい,新しい,アタラシー,,,アタラシイ,アタラシイ,新しい
 2	産業	産業	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サンギョウ,産業,産業,産業,サンギョー,,,サンギョウ,サンギョウコウゾウ,産業構造
@@ -278,6 +290,7 @@
 
 # newdoc id = test-s13
 # sent_id = test-s13
+# parallel_id = jagsd/test13
 # text = 心がないんだ。
 1	心	心	NOUN	名詞-普通名詞-サ変可能	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ココロ,心,心,心,ココロ,,,ココロ,ココロ,心
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -288,6 +301,7 @@
 
 # newdoc id = test-s14
 # sent_id = test-s14
+# parallel_id = jagsd/test14
 # text = そのモサは今何をしているか。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	モサ	モサ	PROPN	名詞-固有名詞-人名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=モサ,モサ,モサ,モサ,モサ,,,モサ,モサ,モサ
@@ -303,6 +317,7 @@
 
 # newdoc id = test-s15
 # sent_id = test-s15
+# parallel_id = jagsd/test15
 # text = 本音としてはこの火に油を注ぎたいけれど。
 1	本音	本音	NOUN	名詞-普通名詞-一般	_	11	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホンネ,本音,本音,本音,ホンネ,,,ホンネ,ホンネ,本音
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,トシテ,として
@@ -321,6 +336,7 @@
 
 # newdoc id = test-s16
 # sent_id = test-s16
+# parallel_id = jagsd/test16
 # text = 25日も楽しみにされてください。
 1	25	25	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二五,25,25,ニゴ,,,ニゴ,ニゴニチ,25日
 2	日	日	NOUN	名詞-普通名詞-助数詞可能	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニチ,日,日,日,ニチ,,,ニチ,ニゴニチ,25日
@@ -335,6 +351,7 @@
 
 # newdoc id = test-s17
 # sent_id = test-s17
+# parallel_id = jagsd/test17
 # text = なんだよなんだよぉ~,わが署に来たのなら教えてくれよぉ~。
 1	なん	何	PRON	代名詞	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ナニ,何,なん,なん,ナン,,,ナン,ナニ,何
 2	だ	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダ,だ
@@ -360,6 +377,7 @@
 
 # newdoc id = test-s18
 # sent_id = test-s18
+# parallel_id = jagsd/test18
 # text = どの本もツッコミどころが山ほどあり,会場内が爆笑の連続でした。
 1	どの	何の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ドノ,何の,どの,どの,ドノ,,,ドノ,ドノ,何の
 2	本	本	NOUN	名詞-普通名詞-一般	_	9	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホン,本,本,本,ホン,,,ホン,ホン,本
@@ -383,6 +401,7 @@
 
 # newdoc id = test-s19
 # sent_id = test-s19
+# parallel_id = jagsd/test19
 # text = 社会への恨みと,破滅させたいという恐ろしいほどの煩悩。
 1	社会	社会	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シャカイ,社会,社会,社会,シャカイ,,,シャカイ,シャカイ,社会
 2	へ	へ	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヘ,へ,へ,へ,エ,,,ヘ,ヘ,へ
@@ -404,6 +423,7 @@
 
 # newdoc id = test-s20
 # sent_id = test-s20
+# parallel_id = jagsd/test20
 # text = とんでもない。
 1	とんでも	とんでも	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=トンデモ,とんでも,とんでも,とんでも,トンデモ,,,トンデモ,トンデモ,とんでも
 2	ない	無い	ADJ	形容詞-非自立可能-形容詞	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|PrevUDLemma=ない|SpaceAfter=No|UnidicInfo=ナイ,無い,ない,ない,ナイ,,,ナイ,ナイ,無い
@@ -411,6 +431,7 @@
 
 # newdoc id = test-s21
 # sent_id = test-s21
+# parallel_id = jagsd/test21
 # text = 抗議デモの継続を宣言した統一教会,日本でも韓国東亜日報の様に襲撃事件が起こる惧れはないのか?
 1	抗議	抗議	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウギ,抗議,抗議,抗議,コーギ,,,コウギ,コウギデモ,抗議デモ
 2	デモ	デモ	NOUN	名詞-普通名詞-サ変可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=デモ,デモ,デモ,デモ,デモ,,,デモ,コウギデモ,抗議デモ
@@ -445,6 +466,7 @@
 
 # newdoc id = test-s22
 # sent_id = test-s22
+# parallel_id = jagsd/test22
 # text = ついつい言葉だけで机上の空論をこねがちな自分は,ここは激しく自戒ですね...
 1	ついつい	ついつい	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ツイツイ,ついつい,ついつい,ついつい,ツイツイ,,,ツイツイ,ツイツイ,ついつい
 2	言葉	言葉	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コトバ,言葉,言葉,言葉,コトバ,,,コトバ,コトバ,言葉
@@ -472,6 +494,7 @@
 
 # newdoc id = test-s23
 # sent_id = test-s23
+# parallel_id = jagsd/test23
 # text = 当選して市長になってもなお,摂理との関係を明らかにしようとしないのは,とても残念。
 1	当選	当選	VERB	名詞-普通名詞-サ変可能	_	6	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=トウセン,当選,当選,当選,トーセン,,,トウセン,トウセンスル,当選する
 2	し	為る	AUX	動詞-非自立可能-サ行変格	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,トウセンスル,当選する
@@ -503,6 +526,7 @@
 
 # newdoc id = test-s24
 # sent_id = test-s24
+# parallel_id = jagsd/test24
 # text = この夏が実は最大の山場になります。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	夏	夏	NOUN	名詞-普通名詞-副詞可能	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナツ,夏,夏,夏,ナツ,,,ナツ,ナツ,夏
@@ -519,6 +543,7 @@
 
 # newdoc id = test-s25
 # sent_id = test-s25
+# parallel_id = jagsd/test25
 # text = 政府がもっと宗教法人の定義を厳しくし,こういう団体は排除すべき。
 1	政府	政府	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイフ,政府,政府,政府,セーフ,,,セイフ,セイフ,政府
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -542,6 +567,7 @@
 
 # newdoc id = test-s26
 # sent_id = test-s26
+# parallel_id = jagsd/test26
 # text = まあ,それが親心だ。
 1	まあ	まあ	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=マア,まあ,まあ,まあ,マー,,,マア,マア,まあ
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -553,6 +579,7 @@
 
 # newdoc id = test-s27
 # sent_id = test-s27
+# parallel_id = jagsd/test27
 # text = 大川隆法氏を支持する人が挙げた主な理由は,以下のとおり。
 1	大川	大川	PROPN	名詞-固有名詞-人名-姓	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=オオカワ,オオカワ,大川,大川,オーカワ,,,オオカワ,オオカワリュウホウシ,大川隆法氏
 2	隆法	隆法	PROPN	名詞-固有名詞-人名-名	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=リュウホウ,リュウホウ,隆法,隆法,リューホー,,,リュウホウ,オオカワリュウホウシ,大川隆法氏
@@ -575,6 +602,7 @@
 
 # newdoc id = test-s28
 # sent_id = test-s28
+# parallel_id = jagsd/test28
 # text = すごくそういうところを引っかかる感じですか?
 1	すごく	凄い	ADJ	形容詞-一般-形容詞	_	6	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごく,すごい,スゴク,,,スゴイ,スゴイ,凄い
 2	そう	そう	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ソウ,そう,そう,そう,ソー,,,ソウ,ソウ,そう
@@ -589,6 +617,7 @@
 
 # newdoc id = test-s29
 # sent_id = test-s29
+# parallel_id = jagsd/test29
 # text = この記事が本当ならいくつかの問題がはっきり見えてきます。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	記事	記事	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キジ,記事,記事,記事,キジ,,,キジ,キジ,記事
@@ -610,6 +639,7 @@
 
 # newdoc id = test-s30
 # sent_id = test-s30
+# parallel_id = jagsd/test30
 # text = 今,何もそれは達成されていない。
 1	今	今	ADV	名詞-普通名詞-副詞可能	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イマ,今,今,今,イマ,,,イマ,イマ,今
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -627,6 +657,7 @@
 
 # newdoc id = test-s31
 # sent_id = test-s31
+# parallel_id = jagsd/test31
 # text = 身勝手すぎる。
 1	身勝手	身勝手	ADJ	形状詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=動詞-一般-上一段-ガ行|SpaceAfter=No|UnidicInfo=ミガッテ,身勝手,身勝手,身勝手,ミガッテ,,,ミガッテ,ミガッテスギル,身勝手過ぎる
 2	すぎる	過ぎる	VERB	動詞-非自立可能-上一段-ガ行	_	1	advcl	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=動詞-一般-上一段-ガ行|PrevUDLemma=すぎる|SpaceAfter=No|UnidicInfo=スギル,過ぎる,すぎる,すぎる,スギル,,,スギル,ミガッテスギル,身勝手過ぎる
@@ -634,6 +665,7 @@
 
 # newdoc id = test-s32
 # sent_id = test-s32
+# parallel_id = jagsd/test32
 # text = 大人と子供では体質が違うので,“大人に良いものが子供にもいい”とは必ずしもいえません。
 1	大人	大人	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オトナ,大人,大人,大人,オトナ,,,オトナ,オトナ,大人
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -668,6 +700,7 @@
 
 # newdoc id = test-s33
 # sent_id = test-s33
+# parallel_id = jagsd/test33
 # text = 愛人がいたら怒るでしょ。
 1	愛人	愛人	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アイジン,愛人,愛人,愛人,アイジン,,,アイジン,アイジン,愛人
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -679,6 +712,7 @@
 
 # newdoc id = test-s34
 # sent_id = test-s34
+# parallel_id = jagsd/test34
 # text = キリスト教世界でも,たとえばアメリカでは大統領は宣誓式で聖書に手を置くし,共和党の選挙運動ではキリスト教会が力を持っている。
 1	キリスト	キリスト	PROPN	名詞-固有名詞-人名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キリスト,キリスト,キリスト,キリスト,キリスト,,,キリスト,キリストキョウセカイ,キリスト教世界
 2	教	教	NOUN	接尾辞-名詞的-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウ,教,教,教,キョー,,,キョウ,キリストキョウセカイ,キリスト教世界
@@ -721,6 +755,7 @@
 
 # newdoc id = test-s35
 # sent_id = test-s35
+# parallel_id = jagsd/test35
 # text = “カンボジア三百万人大量虐殺をほめたたえ,カンパ集める”
 1	“	“	PUNCT	補助記号-括弧開	_	7	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	カンボジア	カンボジア	PROPN	名詞-固有名詞-地名-国	_	7	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カンボジア,カンボジア,カンボジア,カンボジア,カンボジア,,,カンボジア,カンボジアサンビャクマンニンタイリョウギャクサツ,カンボジア三百万人大量虐殺
@@ -738,6 +773,7 @@
 
 # newdoc id = test-s36
 # sent_id = test-s36
+# parallel_id = jagsd/test36
 # text = 奇しくも,今年1月付けの最新号です。
 1	奇しくも	奇しくも	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=クシクモ,奇しくも,奇しくも,奇しくも,クシクモ,,,クシクモ,クシクモ,奇しくも
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -753,6 +789,7 @@
 
 # newdoc id = test-s37
 # sent_id = test-s37
+# parallel_id = jagsd/test37
 # text = 一番の方法は煎じることです。
 1	一番	一番	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イチバン,一番,一番,一番,イチバン,,,イチバン,イチバン,一番
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -765,6 +802,7 @@
 
 # newdoc id = test-s38
 # sent_id = test-s38
+# parallel_id = jagsd/test38
 # text = それでも,くり返しくり返し,人民に侵略反対を訴え続けて十年がたった。
 1	それ	其れ	CCONJ	代名詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ソレ,其れ,それ,それ,ソレ,,,ソレ,ソレデモ,其れでも
 2	で	で	ADP	助詞-格助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,ソレデモ,其れでも
@@ -790,6 +828,7 @@
 
 # newdoc id = test-s39
 # sent_id = test-s39
+# parallel_id = jagsd/test39
 # text = 説教というか,アジテーションが始まります。
 1	説教	説教	NOUN	名詞-普通名詞-サ変可能	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セッキョウ,説教,説教,説教,セッキョー,,,セッキョウ,セッキョウ,説教
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -804,6 +843,7 @@
 
 # newdoc id = test-s40
 # sent_id = test-s40
+# parallel_id = jagsd/test40
 # text = 参考文献リストを見る限りでは,本を書くにあたって読んだのかはわからないが,広範囲に亘って本を読んでいて勉強していることはわかった。
 1	参考	参考	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サンコウ,参考,参考,参考,サンコー,,,サンコウ,サンコウブンケンリスト,参考文献リスト
 2	文献	文献	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ブンケン,文献,文献,文献,ブンケン,,,ブンケン,サンコウブンケンリスト,参考文献リスト
@@ -852,6 +892,7 @@
 
 # newdoc id = test-s41
 # sent_id = test-s41
+# parallel_id = jagsd/test41
 # text = 文殊菩薩私が幸福になっていない以上,世界伝道などはありえない!
 1	文殊	文殊	PROPN	名詞-固有名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=モンジュ,文殊,文殊,文殊,モンジュ,,,モンジュ,モンジュボサツ,文殊菩薩
 2	菩薩	菩薩	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ボサツ,菩薩,菩薩,菩薩,ボサツ,,,ボサツ,モンジュボサツ,文殊菩薩
@@ -876,6 +917,7 @@
 
 # newdoc id = test-s42
 # sent_id = test-s42
+# parallel_id = jagsd/test42
 # text = しばらくの完全休養とリハビリが必要とのことでした。
 1	しばらく	暫く	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=シバラク,暫く,しばらく,しばらく,シバラク,,,シバラク,シバラク,暫く
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -894,6 +936,7 @@
 
 # newdoc id = test-s43
 # sent_id = test-s43
+# parallel_id = jagsd/test43
 # text = いまのところ,訴訟沙汰になったとか,米・中・朝の軍が幸福の科学を襲撃したといった話は聞きません。
 1	いま	今	NOUN	名詞-普通名詞-副詞可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イマ,今,いま,いま,イマ,,,イマ,イマ,今
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -934,6 +977,7 @@
 
 # newdoc id = test-s44
 # sent_id = test-s44
+# parallel_id = jagsd/test44
 # text = バームクーヘンでも周りにお砂糖がたっぷり付いているもの。
 1	バームクーヘン	バウムクーヘン	NOUN	名詞-普通名詞-一般	_	10	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バウムクーヘン,バウムクーヘン,バームクーヘン,バームクーヘン,バームクーヘン,,,バームクーヘン,バームクーヘン,バームクーヘン
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	cop	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -952,6 +996,7 @@
 
 # newdoc id = test-s45
 # sent_id = test-s45
+# parallel_id = jagsd/test45
 # text = しかし,心配には及ばないようです。
 1	しかし	然し	CCONJ	接続詞	_	6	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -966,6 +1011,7 @@
 
 # newdoc id = test-s46
 # sent_id = test-s46
+# parallel_id = jagsd/test46
 # text = いったい,“次世紀ファーム研究所”とは何なのか。
 1	いったい	一体	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イッタイ,一体,いったい,いったい,イッタイ,,,イッタイ,イッタイ,一体
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -986,6 +1032,7 @@
 
 # newdoc id = test-s47
 # sent_id = test-s47
+# parallel_id = jagsd/test47
 # text = その後,一部の会員に渡すための賞状にサインしてくださいと頼まれ,サインをいたしました。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-副詞可能	_	18	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -1016,6 +1063,7 @@
 
 # newdoc id = test-s48
 # sent_id = test-s48
+# parallel_id = jagsd/test48
 # text = 事前に海老澤代表からは“40歳くらいとお若いけれど,とても家系のことに詳しい先生”と聞かされていた。
 1	事前	事前	NOUN	名詞-普通名詞-一般	_	25	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジゼン,事前,事前,事前,ジゼン,,,ジゼン,ジゼン,事前
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1050,6 +1098,7 @@
 
 # newdoc id = test-s49
 # sent_id = test-s49
+# parallel_id = jagsd/test49
 # text = “1000万円当たりますように”というのもありました。
 1	“	“	PUNCT	補助記号-括弧開	_	4	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	1000	1000	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イッセン,一千,1000,1000,イッセン,,,イッセン,イッセンマンエン,1000万円
@@ -1071,6 +1120,7 @@
 
 # newdoc id = test-s50
 # sent_id = test-s50
+# parallel_id = jagsd/test50
 # text = いつもどおりなので,たぶん何も問題ありません。
 1	いつ	何時	PRON	代名詞	_	12	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イツ,何時,いつ,いつ,イツ,,,イツ,イツモドオリ,何時も通り
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,イツモドオリ,何時も通り
@@ -1090,6 +1140,7 @@
 
 # newdoc id = test-s51
 # sent_id = test-s51
+# parallel_id = jagsd/test51
 # text = 震災に乗じて末端信者から献金を集めようとの意図が判る。
 1	震災	震災	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンサイ,震災,震災,震災,シンサイ,,,シンサイ,シンサイ,震災
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1110,6 +1161,7 @@
 
 # newdoc id = test-s52
 # sent_id = test-s52
+# parallel_id = jagsd/test52
 # text = Ad Plannerもサイトの月間利用者の推定データだと思うので,Twitterアカウント数でも,Twitter利用者数でもないだろう。
 1	Ad	Ad	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|UnidicInfo=アド,アド,Ad,Ad,アド,,,アド,アドプランナー,AdPlanner
 2	Planner	Planner	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=プランナー,プランナー,Planner,Planner,プランナー,,,プランナー,アドプランナー,AdPlanner
@@ -1146,6 +1198,7 @@
 
 # newdoc id = test-s53
 # sent_id = test-s53
+# parallel_id = jagsd/test53
 # text = “天聖稲荷大権現神社”を出て,“箱根大天狗山神社”へ向かう。
 1	“	“	PUNCT	補助記号-括弧開	_	6	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	天聖	天聖	NOUN	名詞-普通名詞-一般	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テンセイ,天聖,天聖,天聖,テンセー,,,テンセイ,テンセイイナリダイゴンゲンジンジャ,天聖稲荷大権現神社
@@ -1171,6 +1224,7 @@
 
 # newdoc id = test-s54
 # sent_id = test-s54
+# parallel_id = jagsd/test54
 # text = みんな自分の立場から主張しています。
 1	みんな	皆	ADV	名詞-普通名詞-副詞可能	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ミナ,皆,みんな,みんな,ミンナ,,,ミンナ,ミナ,皆
 2	自分	自分	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
@@ -1186,6 +1240,7 @@
 
 # newdoc id = test-s55
 # sent_id = test-s55
+# parallel_id = jagsd/test55
 # text = “鶴”は統一教会教祖・文鮮明の妻,韓鶴子が由来か。
 1	“	“	PUNCT	補助記号-括弧開	_	2	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	鶴	鶴	NOUN	名詞-普通名詞-一般	_	17	nsubj:outer	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ツル,鶴,鶴,鶴,ツル,,,ツル,ツル,鶴
@@ -1209,6 +1264,7 @@
 
 # newdoc id = test-s56
 # sent_id = test-s56
+# parallel_id = jagsd/test56
 # text = “心筋梗塞になったが神様に命を救っていただいた”
 1	“	“	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	心筋	心筋	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンキン,心筋,心筋,心筋,シンキン,,,シンキン,シンキンコウソク,心筋梗塞
@@ -1230,6 +1286,7 @@
 
 # newdoc id = test-s57
 # sent_id = test-s57
+# parallel_id = jagsd/test57
 # text = 広告審査部への取り次ぎは読者センターの判断に委ねるとのこと。
 1	広告	広告	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウコク,広告,広告,広告,コーコク,,,コウコク,コウコクシンサブ,広告審査部
 2	審査	審査	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンサ,審査,審査,審査,シンサ,,,シンサ,コウコクシンサブ,広告審査部
@@ -1251,6 +1308,7 @@
 
 # newdoc id = test-s58
 # sent_id = test-s58
+# parallel_id = jagsd/test58
 # text = ビデオセンタースタッフも参加。
 1	ビデオ	ビデオ	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ビデオ,ビデオ,ビデオ,ビデオ,ビデオ,,,ビデオ,ビデオセンタースタッフ,ビデオセンタースタッフ
 2	センター	センター	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センター,センター,センター,センター,センター,,,センター,ビデオセンタースタッフ,ビデオセンタースタッフ
@@ -1261,6 +1319,7 @@
 
 # newdoc id = test-s59
 # sent_id = test-s59
+# parallel_id = jagsd/test59
 # text = 空気を読もうとする姿勢が見られ,不思議な気持ちになりました。
 1	空気	空気	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クウキ,空気,空気,空気,クーキ,,,クウキ,クウキ,空気
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -1283,6 +1342,7 @@
 
 # newdoc id = test-s60
 # sent_id = test-s60
+# parallel_id = jagsd/test60
 # text = だが,生真面目な彼は少し困った顔をしてこう言った。
 1	だ	だ	CCONJ	助動詞-助動詞-ダ	_	16	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダガ,だが
 2	が	が	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ダガ,だが
@@ -1305,6 +1365,7 @@
 
 # newdoc id = test-s61
 # sent_id = test-s61
+# parallel_id = jagsd/test61
 # text = どうぞ取材に来てください。
 1	どうぞ	どうぞ	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ドウゾ,どうぞ,どうぞ,どうぞ,ドーゾ,,,ドウゾ,ドウゾ,どうぞ
 2	取材	取材	NOUN	名詞-普通名詞-サ変可能	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュザイ,取材,取材,取材,シュザイ,,,シュザイ,シュザイ,取材
@@ -1316,6 +1377,7 @@
 
 # newdoc id = test-s62
 # sent_id = test-s62
+# parallel_id = jagsd/test62
 # text = でも党が結成されたときは,けっこう報道されていましたよ。
 1	で	で	CCONJ	助詞-格助詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デモ,でも
 2	も	も	ADP	助詞-係助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,デモ,でも
@@ -1341,6 +1403,7 @@
 
 # newdoc id = test-s63
 # sent_id = test-s63
+# parallel_id = jagsd/test63
 # text = 陳述書に“現在も通っている”と書いてあるが?
 1	陳述	陳述	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チンジュツ,陳述,陳述,陳述,チンジュツ,,,チンジュツ,チンジュツショ,陳述書
 2	書	書	NOUN	接尾辞-名詞的-一般	_	12	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショ,書,書,書,ショ,,,ショ,チンジュツショ,陳述書
@@ -1361,6 +1424,7 @@
 
 # newdoc id = test-s64
 # sent_id = test-s64
+# parallel_id = jagsd/test64
 # text = ファンの皆様には混乱を招いてしまい,誠に申し訳ございません。
 1	ファン	ファン	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ファン,ファン,ファン,ファン,ファン,,,ファン,ファン,ファン
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1384,6 +1448,7 @@
 
 # newdoc id = test-s65
 # sent_id = test-s65
+# parallel_id = jagsd/test65
 # text = 教祖の浮気性,あくなき欲望。
 1	教祖	教祖	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウソ,教祖,教祖,教祖,キョーソ,,,キョウソ,キョウソ,教祖
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1397,6 +1462,7 @@
 
 # newdoc id = test-s66
 # sent_id = test-s66
+# parallel_id = jagsd/test66
 # text = さっぱり意味がわかりません。
 1	さっぱり	さっぱり	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=サッパリ,さっぱり,さっぱり,さっぱり,サッパリ,,,サッパリ,サッパリ,さっぱり
 2	意味	意味	NOUN	名詞-普通名詞-サ変可能	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イミ,意味,意味,意味,イミ,,,イミ,イミ,意味
@@ -1408,6 +1474,7 @@
 
 # newdoc id = test-s67
 # sent_id = test-s67
+# parallel_id = jagsd/test67
 # text = 心よりお悔やみ申し上げます。
 1	心	心	NOUN	名詞-普通名詞-サ変可能	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ココロ,心,心,心,ココロ,,,ココロ,ココロ,心
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -1419,6 +1486,7 @@
 
 # newdoc id = test-s68
 # sent_id = test-s68
+# parallel_id = jagsd/test68
 # text = そんな俗世の快楽を楽しむ彼も,インタビューには“洗礼を受けるつもり”と答えている。
 1	そんな	そんな	PRON	連体詞	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソンナ,そんな,そんな,そんな,ソンナ,,,ソンナ,ソンナ,そんな
 2	俗世	俗世	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゾクセ,俗世,俗世,俗世,ゾクセ,,,ゾクセ,ゾクセ,俗世
@@ -1446,6 +1514,7 @@
 
 # newdoc id = test-s69
 # sent_id = test-s69
+# parallel_id = jagsd/test69
 # text = 記者はその勝手な言い分に対し,“暑い中,わざわざ来てくれた警官に失礼だろう!”
 1	記者	記者	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キシャ,記者,記者,記者,キシャ,,,キシャ,キシャ,記者
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -1474,6 +1543,7 @@
 
 # newdoc id = test-s70
 # sent_id = test-s70
+# parallel_id = jagsd/test70
 # text = というか,返す刀で互いを批判し合っています。
 1	と	と	ADP	助詞-格助詞	_	2	case	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
 2	いう	言う	VERB	動詞-一般-五段-ワア行	_	10	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-ワア行|SpaceAfter=No|UnidicInfo=イウ,言う,いう,いう,イウ,,,イウ,イウ,言う
@@ -1494,6 +1564,7 @@
 
 # newdoc id = test-s71
 # sent_id = test-s71
+# parallel_id = jagsd/test71
 # text = みな,事実に基づいて恐怖と憎悪と嘲りを込めてぼくをカルトくんと呼んでくれています。
 1	みな	皆	ADV	名詞-普通名詞-副詞可能	_	20	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ミナ,皆,みな,みな,ミナ,,,ミナ,ミナ,皆
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -1524,6 +1595,7 @@
 
 # newdoc id = test-s72
 # sent_id = test-s72
+# parallel_id = jagsd/test72
 # text = そうだろ?
 1	そう	そう	ADV	副詞	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ソウ,そう,そう,そう,ソー,,,ソウ,ソウ,そう
 2	だろ	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,だろ,だ,ダロ,,,ダ,ダ,だ
@@ -1531,6 +1603,7 @@
 
 # newdoc id = test-s73
 # sent_id = test-s73
+# parallel_id = jagsd/test73
 # text = すごいすごい。
 1	すごい	凄い	ADJ	形容詞-一般-形容詞	_	2	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごい,すごい,スゴイ,,,スゴイ,スゴイ,凄い
 2	すごい	凄い	ADJ	形容詞-一般-形容詞	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごい,すごい,スゴイ,,,スゴイ,スゴイ,凄い
@@ -1538,6 +1611,7 @@
 
 # newdoc id = test-s74
 # sent_id = test-s74
+# parallel_id = jagsd/test74
 # text = もちろん,まじめにやっている宗教法人もあるとは思いますが,やりたい放題やろうと思えばできてしまう構造は変える必要があるように思います。
 1	もちろん	勿論	ADV	副詞	_	11	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=モチロン,勿論,もちろん,もちろん,モチロン,,,モチロン,モチロン,勿論
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -1580,6 +1654,7 @@
 
 # newdoc id = test-s75
 # sent_id = test-s75
+# parallel_id = jagsd/test75
 # text = きっと,地上天国の中にいるのでしょう。
 1	きっと	急度	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=キット,急度,きっと,きっと,キット,,,キット,キット,急度
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -1595,6 +1670,7 @@
 
 # newdoc id = test-s76
 # sent_id = test-s76
+# parallel_id = jagsd/test76
 # text = 過去に自らが主催した飯田氏の講演の映像もYou Tubeから削除しました。
 1	過去	過去	NOUN	名詞-普通名詞-副詞可能	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カコ,過去,過去,過去,カコ,,,カコ,カコ,過去
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1621,6 +1697,7 @@
 
 # newdoc id = test-s77
 # sent_id = test-s77
+# parallel_id = jagsd/test77
 # text = もう一つびっくりしたことと言えば,公立学校の中には保育所が併設されているところがあるということです。
 1	もう	もう	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=モウ,もう,もう,もう,モー,,,モウ,モウ,もう
 2	一	一	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ヒト,一,一,一,ヒト,,,ヒト,ヒトツ,一つ
@@ -1658,6 +1735,7 @@
 
 # newdoc id = test-s78
 # sent_id = test-s78
+# parallel_id = jagsd/test78
 # text = おかしな販売をしているといっても,それはあくまでも刑事事件の話であって,公安部が出てくる筋ではありません。
 1	おかしな	可笑しな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=オカシナ,可笑しな,おかしな,おかしな,オカシナ,,,オカシナ,オカシナ,可笑しな
 2	販売	販売	NOUN	名詞-普通名詞-サ変可能	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハンバイ,販売,販売,販売,ハンバイ,,,ハンバイ,ハンバイ,販売
@@ -1698,6 +1776,7 @@
 
 # newdoc id = test-s79
 # sent_id = test-s79
+# parallel_id = jagsd/test79
 # text = 地方に住む知人の僧侶によると,こんな話もありました。
 1	地方	地方	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チホウ,地方,地方,地方,チホー,,,チホウ,チホウ,地方
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1719,6 +1798,7 @@
 
 # newdoc id = test-s80
 # sent_id = test-s80
+# parallel_id = jagsd/test80
 # text = だからまあ,もう,“殺ってくれ”とは言っておいたから。
 1	だ	だ	CCONJ	助動詞-助動詞-ダ	_	14	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダカラ,だから
 2	から	から	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,ダカラ,だから
@@ -1742,6 +1822,7 @@
 
 # newdoc id = test-s81
 # sent_id = test-s81
+# parallel_id = jagsd/test81
 # text = 右奥に見える重機が,我々に何かを物語っている気がしないでもありません。
 1	右奥	右奥	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ミギオク,右奥,右奥,右奥,ミギオク,,,ミギオク,ミギオク,右奥
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -1770,6 +1851,7 @@
 
 # newdoc id = test-s82
 # sent_id = test-s82
+# parallel_id = jagsd/test82
 # text = とても賢い生徒さんです。
 1	とても	迚も	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=トテモ,迚も,とても,とても,トテモ,,,トテモ,トテモ,迚も
 2	賢い	賢い	ADJ	形容詞-一般-形容詞	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=カシコイ,賢い,賢い,賢い,カシコイ,,,カシコイ,カシコイ,賢い
@@ -1780,6 +1862,7 @@
 
 # newdoc id = test-s83
 # sent_id = test-s83
+# parallel_id = jagsd/test83
 # text = たまたま,お互いに潜入取材の最中だった。
 1	たまたま	偶々	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=タマタマ,偶々,たまたま,たまたま,タマタマ,,,タマタマ,タマタマ,偶々
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -1796,6 +1879,7 @@
 
 # newdoc id = test-s84
 # sent_id = test-s84
+# parallel_id = jagsd/test84
 # text = ホメオパシーのレメディは毒にも薬にもならない“ただの水”と砂糖玉なので,司法解剖によってわかる類の因果関係なんてあるはずもありません。
 1	ホメオパシー	ホメオパチー	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホメオパチー,ホメオパチー,ホメオパシー,ホメオパシー,ホメオパシー,,,ホメオパシー,ホメオパシー,ホメオパシー
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -1842,6 +1926,7 @@
 
 # newdoc id = test-s85
 # sent_id = test-s85
+# parallel_id = jagsd/test85
 # text = まさか松田氏は,男性が倒れる前から消防に通報していたとでもいうつもりだったのでしょうか。
 1	まさか	まさか	ADV	副詞	_	21	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=マサカ,まさか,まさか,まさか,マサカ,,,マサカ,マサカ,まさか
 2	松田	松田	PROPN	名詞-固有名詞-人名-姓	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=マツダ,マツダ,松田,松田,マツダ,,,マツダ,マツダシ,松田氏
@@ -1874,6 +1959,7 @@
 
 # newdoc id = test-s86
 # sent_id = test-s86
+# parallel_id = jagsd/test86
 # text = 是非書けるようになってみたい。
 1	是非	是非	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ゼヒ,是非,是非,是非,ゼヒ,,,ゼヒ,ゼヒ,是非
 2	書ける	書く	VERB	動詞-一般-下一段-カ行	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-下一段-カ行|SpaceAfter=No|UnidicInfo=カク,書く,書ける,書ける,カケル,,,カケル,カケル,書ける
@@ -1887,6 +1973,7 @@
 
 # newdoc id = test-s87
 # sent_id = test-s87
+# parallel_id = jagsd/test87
 # text = どう見ても幸福の科学出版の広告です。
 1	どう	どう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ドウ,どう,どう,どう,ドー,,,ドウ,ドウ,どう
 2	見	見る	VERB	動詞-非自立可能-上一段-マ行	_	10	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-上一段-マ行|PrevUDLemma=みる|SpaceAfter=No|UnidicInfo=ミル,見る,見,見る,ミ,,,ミル,ミル,見る
@@ -1903,6 +1990,7 @@
 
 # newdoc id = test-s88
 # sent_id = test-s88
+# parallel_id = jagsd/test88
 # text = おおつた氏は数年前に勧誘され足立教会の通教組織である【びぎん】に所属,前線での違法な勧誘や霊感商法には関わっていなかったらしい。
 1	おおつた	おおつた	PROPN	名詞-固有名詞-人名-姓	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=オオツタ,オオツタ,おおつた,おおつた,オーツタ,,,オオツタ,オオツタシ,おおつた氏
 2	氏	氏	NOUN	接尾辞-名詞的-一般	_	35	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=シ,氏,氏,氏,シ,,,シ,オオツタシ,おおつた氏
@@ -1948,6 +2036,7 @@
 
 # newdoc id = test-s89
 # sent_id = test-s89
+# parallel_id = jagsd/test89
 # text = 昔,阪神淡路大震災の時は,駅から重いリックを背負って,片道3時間歩いて仮設トイレ等の設置のボランティアに行きましたが,被災地の大変さは,想像以上でした。
 1	昔	昔	ADV	名詞-普通名詞-副詞可能	_	32	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ムカシ,昔,昔,昔,ムカシ,,,ムカシ,ムカシ,昔
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -2000,6 +2089,7 @@
 
 # newdoc id = test-s90
 # sent_id = test-s90
+# parallel_id = jagsd/test90
 # text = かなりの長文になりますが,どうかご了解をお願いします。
 1	かなり	可成	ADJ	形状詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=カナリ,可成,かなり,かなり,カナリ,,,カナリ,カナリ,可成
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2022,6 +2112,7 @@
 
 # newdoc id = test-s91
 # sent_id = test-s91
+# parallel_id = jagsd/test91
 # text = 政党と柴犬を同列に扱うというのも,なかなかです。
 1	政党	政党	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイトウ,政党,政党,政党,セートー,,,セイトウ,セイトウ,政党
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -2041,6 +2132,7 @@
 
 # newdoc id = test-s92
 # sent_id = test-s92
+# parallel_id = jagsd/test92
 # text = ですから,もろもろ客観的解説やツッコミも入ります。
 1	です	です	CCONJ	助動詞-助動詞-デス	_	11	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|PrevUDLemma=だ|SpaceAfter=No|UnidicInfo=デス,です,です,です,デス,,,デス,デスカラ,ですから
 2	から	から	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,デスカラ,ですから
@@ -2058,6 +2150,7 @@
 
 # newdoc id = test-s93
 # sent_id = test-s93
+# parallel_id = jagsd/test93
 # text = その後一行は,池袋駅に移動。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	後	後	NOUN	名詞-普通名詞-副詞可能	_	9	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,ゴ,後
@@ -2072,6 +2165,7 @@
 
 # newdoc id = test-s94
 # sent_id = test-s94
+# parallel_id = jagsd/test94
 # text = 学校法人幸福の科学学園が2013年に関西校を開校するため土地を購入した滋賀県大津市内で,学園開校に反対する声が地元住民から挙がっています。
 1	学校	学校	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ガッコウ,学校,学校,学校,ガッコー,,,ガッコウ,ガッコウホウジンコウフクノカガクガクエン,学校法人幸福の科学学園
 2	法人	法人	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ホウジン,法人,法人,法人,ホージン,,,ホウジン,ガッコウホウジンコウフクノカガクガクエン,学校法人幸福の科学学園
@@ -2119,6 +2213,7 @@
 
 # newdoc id = test-s95
 # sent_id = test-s95
+# parallel_id = jagsd/test95
 # text = では,同じくメディアとしての品性のかけらもない“やや日刊カルト新聞”が,品性のかけらもない宗教者たちの過去のエロ事件を調べてみました。
 1	で	で	CCONJ	助詞-格助詞	_	37	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デハ,では
 2	は	は	ADP	助詞-係助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,デハ,では
@@ -2165,6 +2260,7 @@
 
 # newdoc id = test-s96
 # sent_id = test-s96
+# parallel_id = jagsd/test96
 # text = 宗教は怖い?
 1	宗教	宗教	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュウキョウ,宗教,宗教,宗教,シューキョー,,,シュウキョウ,シュウキョウ,宗教
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -2173,6 +2269,7 @@
 
 # newdoc id = test-s97
 # sent_id = test-s97
+# parallel_id = jagsd/test97
 # text = また渡辺弁護士は,こうも指摘します。
 1	また	又	CCONJ	接続詞	_	9	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	渡辺	渡辺	PROPN	名詞-固有名詞-人名-姓	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=ワタナベ,ワタナベ,渡辺,渡辺,ワタナベ,,,ワタナベ,ワタナベベンゴシ,渡辺弁護士
@@ -2189,6 +2286,7 @@
 
 # newdoc id = test-s98
 # sent_id = test-s98
+# parallel_id = jagsd/test98
 # text = その流れというのもあるので???。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	流れ	流れ	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナガレ,流れ,流れ,流れ,ナガレ,,,ナガレ,ナガレ,流れ
@@ -2206,6 +2304,7 @@
 
 # newdoc id = test-s99
 # sent_id = test-s99
+# parallel_id = jagsd/test99
 # text = 勝利の女神がどちらにほほ笑むか全く分からない展開。
 1	勝利	勝利	NOUN	名詞-普通名詞-サ変可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショウリ,勝利,勝利,勝利,ショーリ,,,ショウリ,ショウリ,勝利
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2223,6 +2322,7 @@
 
 # newdoc id = test-s100
 # sent_id = test-s100
+# parallel_id = jagsd/test100
 # text = ストイコビッチ監督は「浦和は最後まで目を覚ますことがなかった」と、ジョークを交えながら「柏さんにはおめでとうと言いたい」と新王者を称えた。
 1	ストイコビッチ	ストイコビッチ	PROPN	名詞-固有名詞-人名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ストイコビッチ,ストイコビッチ,ストイコビッチ,ストイコビッチ,ストイコビッチ,,,ストイコビッチ,ストイコビッチカントク,ストイコビッチ監督
 2	監督	監督	NOUN	名詞-普通名詞-サ変可能	_	38	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=カントク,監督,監督,監督,カントク,,,カントク,ストイコビッチカントク,ストイコビッチ監督
@@ -2267,6 +2367,7 @@
 
 # newdoc id = test-s101
 # sent_id = test-s101
+# parallel_id = jagsd/test101
 # text = 一団の脇をレスキューボードでライフセーバーが泳ぎ、さらにカヌー、水上バイクもその外に待機する。
 1	一団	一団	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イチダン,一団,一団,一団,イチダン,,,イチダン,イチダン,一団
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2294,6 +2395,7 @@
 
 # newdoc id = test-s102
 # sent_id = test-s102
+# parallel_id = jagsd/test102
 # text = ...あなたが涙を流した「SATC」のエピソードは?
 1	.	.	PUNCT	補助記号-句点	_	14	punct	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=補助記号-句点|SpaceAfter=No|UnidicInfo=,．,.,.,,,,,,．
 2	.	.	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-句点|SpaceAfter=No|UnidicInfo=,．,.,.,,,,,,．
@@ -2314,6 +2416,7 @@
 
 # newdoc id = test-s103
 # sent_id = test-s103
+# parallel_id = jagsd/test103
 # text = ジャンボ機の愛称で知られるボーイング747のうち、約20年にわたって日航で活躍してきた国内線仕様の「400D型」の引退フライトツアーが19日あり、参加した約450人が乗り込み別れを惜しんだ。
 1	ジャンボ	ジャンボ	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジャンボ,ジャンボ,ジャンボ,ジャンボ,ジャンボ,,,ジャンボ,ジャンボキ,ジャンボ機
 2	機	機	NOUN	名詞-普通名詞-助数詞可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キ,機,機,機,キ,,,キ,ジャンボキ,ジャンボ機
@@ -2374,6 +2477,7 @@
 
 # newdoc id = test-s104
 # sent_id = test-s104
+# parallel_id = jagsd/test104
 # text = センター街の片隅で、撮影の準備を始める大島優子さんとスタッフ。
 1	センター	センター	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センター,センター,センター,センター,センター,,,センター,センターガイ,センター街
 2	街	街	NOUN	接尾辞-名詞的-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ガイ,街,街,街,ガイ,,,ガイ,センターガイ,センター街
@@ -2395,6 +2499,7 @@
 
 # newdoc id = test-s105
 # sent_id = test-s105
+# parallel_id = jagsd/test105
 # text = この背景には、アメリカの金融緩和の影響で多額の資金が原油の先物市場に流れ込んでいることや、新興国の需要の拡大で国際的な原油取引の価格が上昇していることがあります。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	背景	背景	NOUN	名詞-普通名詞-一般	_	43	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハイケイ,背景,背景,背景,ハイケー,,,ハイケイ,ハイケイ,背景
@@ -2450,6 +2555,7 @@
 
 # newdoc id = test-s106
 # sent_id = test-s106
+# parallel_id = jagsd/test106
 # text = 本格的だし、絶対に効くと思うので、いろいろな人に覚えてもらいたいです。
 1	本格	本格	NOUN	名詞-普通名詞-一般	_	8	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ホンカク,本格,本格,本格,ホンカク,,,ホンカク,ホンカクテキ,本格的
 2	的	的	PART	接尾辞-形状詞的	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=テキ,的,的,的,テキ,,,テキ,ホンカクテキ,本格的
@@ -2477,6 +2583,7 @@
 
 # newdoc id = test-s107
 # sent_id = test-s107
+# parallel_id = jagsd/test107
 # text = 仮設を出た後に住みたい場所では、岩手、宮城の約6割が「以前住んでいた場所に近い高台」「同じ市町村」、福島の7割が「以前住んでいた場所」と答えた。
 1	仮設	仮設	NOUN	名詞-普通名詞-サ変可能	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カセツ,仮設,仮設,仮設,カセツ,,,カセツ,カセツ,仮設
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -2536,6 +2643,7 @@
 
 # newdoc id = test-s108
 # sent_id = test-s108
+# parallel_id = jagsd/test108
 # text = 当初、アメリカ映画として作る発想から始まったので英語映画にしたが、舞台にニューヨークを選ばなかったのは、東京を壊すべきだと思ったから。
 1	当初	当初	ADV	名詞-普通名詞-副詞可能	_	11	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2581,6 +2689,7 @@
 
 # newdoc id = test-s109
 # sent_id = test-s109
+# parallel_id = jagsd/test109
 # text = このページに掲載されている記事・写真・図表などの無断転載を禁じます。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	ページ	ページ	NOUN	名詞-普通名詞-助数詞可能	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ページ,ページ,ページ,ページ,ページ,,,ページ,ページ,ページ
@@ -2606,6 +2715,7 @@
 
 # newdoc id = test-s110
 # sent_id = test-s110
+# parallel_id = jagsd/test110
 # text = 記者がアジアを飛び回っているせいか、やはりアジアの方が多いです。
 1	記者	記者	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キシャ,記者,記者,記者,キシャ,,,キシャ,キシャ,記者
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -2628,6 +2738,7 @@
 
 # newdoc id = test-s111
 # sent_id = test-s111
+# parallel_id = jagsd/test111
 # text = 警視庁は今後、役員らから事情を聴くなど、検査妨害の全容を解明する方針。
 1	警視	警視	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ケイシ,警視,警視,警視,ケーシ,,,ケイシ,ケイシチョウ,警視庁
 2	庁	庁	NOUN	接尾辞-名詞的-一般	_	19	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=チョウ,庁,庁,庁,チョー,,,チョウ,ケイシチョウ,警視庁
@@ -2654,6 +2765,7 @@
 
 # newdoc id = test-s112
 # sent_id = test-s112
+# parallel_id = jagsd/test112
 # text = 70年ぶりに生息が確認されたクニマスの保護に向け、西湖で地元の漁業協同組合が、禁漁区を自主的に設定しました。
 1	70	70	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ナナジュウ,七十,70,70,ナナジュー,,,ナナジュウ,ナナジュウネンブリ,70年ぶり
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ナナジュウネンブリ,70年ぶり
@@ -2694,6 +2806,7 @@
 
 # newdoc id = test-s113
 # sent_id = test-s113
+# parallel_id = jagsd/test113
 # text = 谷川容疑者は政治団体の構成員を名乗っていて、当時、団体の車両が中国に対する批判を繰り返す街宣活動を行っていたという。
 1	谷川	谷川	PROPN	名詞-固有名詞-人名-姓	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=タニガワ,タニガワ,谷川,谷川,タニガワ,,,タニガワ,タニガワヨウギシャ,谷川容疑者
 2	容疑	容疑	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=ヨウギ,容疑,容疑,容疑,ヨーギ,,,ヨウギ,タニガワヨウギシャ,谷川容疑者
@@ -2735,6 +2848,7 @@
 
 # newdoc id = test-s114
 # sent_id = test-s114
+# parallel_id = jagsd/test114
 # text = やがて、書きためた曲を携え、「ウクレレわらべうた」として児童館などでライブを始め、そこで出会った絵本の読み聞かせをする父親たちのグループ「パパ’S絵本プロジェクト」の活動に合流。
 1	やがて	軈て	ADV	副詞	_	22	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ヤガテ,軈て,やがて,やがて,ヤガテ,,,ヤガテ,ヤガテ,軈て
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -2785,6 +2899,7 @@
 
 # newdoc id = test-s115
 # sent_id = test-s115
+# parallel_id = jagsd/test115
 # text = 昨年4月、オバマ米大統領が「核兵器のない世界を目指す」と訴えたプラハ演説以降、潮目が変わってきているのかなと、かすかな期待を抱く。
 1	昨年	昨年	NOUN	名詞-普通名詞-副詞可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サクネン,昨年,昨年,昨年,サクネン,,,サクネン,サクネン,昨年
 2	4	4	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=シ,四,4,4,シ,,,シ,シガツ,4月
@@ -2831,6 +2946,7 @@
 
 # newdoc id = test-s116
 # sent_id = test-s116
+# parallel_id = jagsd/test116
 # text = だが08年4月、あごを骨折し3つ目の王座から陥落。
 1	だ	だ	CCONJ	助動詞-助動詞-ダ	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ダ,だ,だ,だ,ダ,,,ダ,ダガ,だが
 2	が	が	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ダガ,だが
@@ -2854,6 +2970,7 @@
 
 # newdoc id = test-s117
 # sent_id = test-s117
+# parallel_id = jagsd/test117
 # text = 今期の経常利益は急回復する見通しだが、中期的に見れば、震災の影響はジワジワ効いてくる。
 1	今期	今期	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コンキ,今期,今期,今期,コンキ,,,コンキ,コンキ,今期
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -2885,6 +3002,7 @@
 
 # newdoc id = test-s118
 # sent_id = test-s118
+# parallel_id = jagsd/test118
 # text = 鋭い眼光でこちらを睨み付けるニノ、ヴィジュアル系のように自分を抱きしめるニノ、壁にへばり付き何かに怯えるニノ......。
 1	鋭い	鋭い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=スルドイ,鋭い,鋭い,鋭い,スルドイ,,,スルドイ,スルドイ,鋭い
 2	眼光	眼光	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ガンコウ,眼光,眼光,眼光,ガンコー,,,ガンコウ,ガンコウ,眼光
@@ -2922,6 +3040,7 @@
 
 # newdoc id = test-s119
 # sent_id = test-s119
+# parallel_id = jagsd/test119
 # text = パク・チウォン代表は「25人の将軍級を懲戒するというが、こうした重大な問題を監査院の監査で懲戒程度で終わらせることはありえない」、「軍法会議に回付して、軍検察が徹底した調査をするように要求する」と述べた。
 1	パク	パク	PROPN	名詞-固有名詞-人名-姓	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=パク,パク,パク,パク,パク,,,パク,パクチオンダイヒョウ,パク・チウォン代表
 2	・	・	SYM	補助記号-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,パクチオンダイヒョウ,パク・チウォン代表
@@ -2994,6 +3113,7 @@
 
 # newdoc id = test-s120
 # sent_id = test-s120
+# parallel_id = jagsd/test120
 # text = SMBC日興証券は2012年秋をめどにシンガポール拠点を開設する。
 1	SMBC	SMBC	PROPN	名詞-固有名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=エスエムビーシー,ＳＭＢＣ,SMBC,SMBC,エスエムビーシー,,,エスエムビーシー,エスエムビーシーニッコウショウケン,SMBC日興証券
 2	日興	日興	PROPN	名詞-固有名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ニッコウ,日興,日興,日興,ニッコー,,,ニッコウ,エスエムビーシーニッコウショウケン,SMBC日興証券
@@ -3014,6 +3134,7 @@
 
 # newdoc id = test-s121
 # sent_id = test-s121
+# parallel_id = jagsd/test121
 # text = 3年ぶりにボランチでプレーしたので自己評価は出来ない。
 1	3	3	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=サン,三,3,3,サン,,,サン,サンネンブリ,3年ぶり
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,サンネンブリ,3年ぶり
@@ -3035,6 +3156,7 @@
 
 # newdoc id = test-s122
 # sent_id = test-s122
+# parallel_id = jagsd/test122
 # text = わずか半年間に重賞を3勝し、血統馬にふさわしい活躍を見せてきた。
 1	わずか	僅か	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ワズカ,僅か,わずか,わずか,ワズカ,,,ワズカ,ワズカ,僅か
 2	半年	半年	NOUN	名詞-普通名詞-副詞可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハントシ,半年,半年,半年,ハントシ,,,ハントシ,ハントシカン,半年間
@@ -3060,6 +3182,7 @@
 
 # newdoc id = test-s123
 # sent_id = test-s123
+# parallel_id = jagsd/test123
 # text = 伏兵の一発を含む11安打9得点で静岡県勢として春通算50勝を達成。
 1	伏兵	伏兵	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フクヘイ,伏兵,伏兵,伏兵,フクヘー,,,フクヘイ,フクヘイ,伏兵
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -3087,6 +3210,7 @@
 
 # newdoc id = test-s124
 # sent_id = test-s124
+# parallel_id = jagsd/test124
 # text = メディアから「45年の歴史を持つメジャーリーグのドラフト史上で『最高の選手』」と言われていたストラスバーグだが、この契約金は各方面で話題になった。
 1	メディア	メディア	NOUN	名詞-普通名詞-一般	_	24	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=メディア,メディア,メディア,メディア,メディア,,,メディア,メディア,メディア
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -3135,6 +3259,7 @@
 
 # newdoc id = test-s125
 # sent_id = test-s125
+# parallel_id = jagsd/test125
 # text = 私たち去る大戦の悲惨な教訓から戦後「命どぅ宝」、基地のない平和で安全な沖縄を希求してきました。
 1	私	私	PRON	代名詞	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシタチ,私達
 2	たち	達	NOUN	接尾辞-名詞的-一般	_	26	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=タチ,達,たち,たち,タチ,,,タチ,ワタシタチ,私達
@@ -3171,6 +3296,7 @@
 
 # newdoc id = test-s126
 # sent_id = test-s126
+# parallel_id = jagsd/test126
 # text = 5/13に放送されるフジテレビ系「僕らの音楽」にて、福原美穂とAIという豪華共演が決定した。
 1	5	5	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ゴ,五,5,5,ゴ,,,ゴ,ゴイチサン,5/13
 2	/	/	SYM	補助記号-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=,/,/,/,,,,,ゴイチサン,5/13
@@ -3206,6 +3332,7 @@
 
 # newdoc id = test-s127
 # sent_id = test-s127
+# parallel_id = jagsd/test127
 # text = そして次巻「約束の地で」では一気に時間が20年後へと飛ぶ。
 1	そして	そして	CCONJ	接続詞	_	20	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	次巻	次巻	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジカン,次巻,次巻,次巻,ジカン,,,ジカン,ジカン,次巻
@@ -3231,6 +3358,7 @@
 
 # newdoc id = test-s128
 # sent_id = test-s128
+# parallel_id = jagsd/test128
 # text = もちろん、運転可能!
 1	もちろん	勿論	ADV	副詞	_	4	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=モチロン,勿論,もちろん,もちろん,モチロン,,,モチロン,モチロン,勿論
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3240,6 +3368,7 @@
 
 # newdoc id = test-s129
 # sent_id = test-s129
+# parallel_id = jagsd/test129
 # text = ビーチや公園、家やオフィスなど様々な場所に持ち運んで楽しむことができます。
 1	ビーチ	ビーチ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ビーチ,ビーチ,ビーチ,ビーチ,ビーチ,,,ビーチ,ビーチ,ビーチ
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -3264,6 +3393,7 @@
 
 # newdoc id = test-s130
 # sent_id = test-s130
+# parallel_id = jagsd/test130
 # text = 2人は以前、男性に向かって石を投げた際に投げ返されたり、喫煙していてとがめられたりしたことがあり、恨みを募らせていたという。
 1	2人	二人	NOUN	名詞-普通名詞-副詞可能	_	35	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フタリ,二人,2人,2人,フタリ,,,フタリ,フタリ,2人
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3310,6 +3440,7 @@
 
 # newdoc id = test-s131
 # sent_id = test-s131
+# parallel_id = jagsd/test131
 # text = 深刻度がもっとも高い「緊急」とされるのは、「Windows」に関するプログラム4件。
 1	深刻	深刻	ADJ	形状詞-一般	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンコク,深刻,深刻,深刻,シンコク,,,シンコク,シンコクド,深刻度
 2	度	度	NOUN	名詞-普通名詞-助数詞可能	_	5	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ド,度,度,度,ド,,,ド,シンコクド,深刻度
@@ -3337,6 +3468,7 @@
 
 # newdoc id = test-s132
 # sent_id = test-s132
+# parallel_id = jagsd/test132
 # text = ただ、この質問に対する回答は、誰かに回答が固まることなく、1位の木村拓哉さんでも獲得率が5%以下と幅広くいろいろな人の名前が挙がる結果となりました。
 1	ただ	唯	CCONJ	接続詞	_	44	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=タダ,唯,ただ,ただ,タダ,,,タダ,タダ,唯
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -3388,6 +3520,7 @@
 
 # newdoc id = test-s133
 # sent_id = test-s133
+# parallel_id = jagsd/test133
 # text = 早ければ2010年度から行う方向となった。
 1	早けれ	早い	ADJ	形容詞-一般-形容詞	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=ハヤイ,早い,早けれ,早い,ハヤケレ,,,ハヤイ,ハヤイ,早い
 2	ば	ば	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-接続助詞|SpaceAfter=No|UnidicInfo=バ,ば,ば,ば,バ,,,バ,バ,ば
@@ -3403,6 +3536,7 @@
 
 # newdoc id = test-s134
 # sent_id = test-s134
+# parallel_id = jagsd/test134
 # text = 車を所有する人の割合は前回平成13年度調査の71・2%から11・9ポイント減少した。
 1	車	車	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クルマ,車,車,車,クルマ,,,クルマ,クルマ,車
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -3434,6 +3568,7 @@
 
 # newdoc id = test-s135
 # sent_id = test-s135
+# parallel_id = jagsd/test135
 # text = 大宮は終盤、攻勢を仕掛けるも得点は奪えず。
 1	大宮	大宮	PROPN	名詞-固有名詞-地名-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=オオミヤ,オオミヤ,大宮,大宮,オーミヤ,,,オオミヤ,オオミヤ,大宮
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3451,6 +3586,7 @@
 
 # newdoc id = test-s136
 # sent_id = test-s136
+# parallel_id = jagsd/test136
 # text = 本当に申し訳ない。
 1	本当	本当	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホントウ,本当,本当,本当,ホント,,,ホント,ホントウ,本当
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3460,6 +3596,7 @@
 
 # newdoc id = test-s137
 # sent_id = test-s137
+# parallel_id = jagsd/test137
 # text = 独立型チャペルは、本格的なヨーロピアンテイスト。
 1	独立	独立	NOUN	名詞-普通名詞-サ変形状詞可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドクリツ,独立,独立,独立,ドクリツ,,,ドクリツ,ドクリツガタチャペル,独立型チャペル
 2	型	型	NOUN	接尾辞-名詞的-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ガタ,型,型,型,ガタ,,,ガタ,ドクリツガタチャペル,独立型チャペル
@@ -3475,6 +3612,7 @@
 
 # newdoc id = test-s138
 # sent_id = test-s138
+# parallel_id = jagsd/test138
 # text = 教室に火の気はなく、白河署と矢吹消防署は30日、実況見分し原因を調べる。
 1	教室	教室	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウシツ,教室,教室,教室,キョーシツ,,,キョウシツ,キョウシツ,教室
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3502,6 +3640,7 @@
 
 # newdoc id = test-s139
 # sent_id = test-s139
+# parallel_id = jagsd/test139
 # text = 一方で、西側の政治家や専門家の多くは、ノーベル賞委員会の決定は非常に理にかなったものであるとの評価を与えている。
 1	一方	一方	NOUN	名詞-普通名詞-副詞可能	_	35	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3544,6 +3683,7 @@
 
 # newdoc id = test-s140
 # sent_id = test-s140
+# parallel_id = jagsd/test140
 # text = 午後に入ると139円80銭付近での推移となり、結局は14銭高の139円78銭で引けた。
 1	午後	午後	NOUN	名詞-普通名詞-副詞可能	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴゴ,午後,午後,午後,ゴゴ,,,ゴゴ,ゴゴ,午後
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -3577,6 +3717,7 @@
 
 # newdoc id = test-s141
 # sent_id = test-s141
+# parallel_id = jagsd/test141
 # text = ゴールドマン・サックス証券は257社、日本最大手の野村証券は608社。
 1	ゴールドマン	ゴールドマン	PROPN	名詞-固有名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ゴールドマン,ゴールドマン,ゴールドマン,ゴールドマン,ゴールドマン,,,ゴールドマン,ゴールドマンサックスショウケン,ゴールドマン・サックス証券
 2	・	・	SYM	補助記号-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,ゴールドマンサックスショウケン,ゴールドマン・サックス証券
@@ -3599,6 +3740,7 @@
 
 # newdoc id = test-s142
 # sent_id = test-s142
+# parallel_id = jagsd/test142
 # text = 知床半島も、はじめて訪れた1971年から大きく変わり、羅臼の漁師の家も番屋も立派になり、ウトロには無数のホテルが建ち、「地の果て」とは言えない様変わりをしています。
 1	知床	知床	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=シレトコ,シレトコ,知床,知床,シレトコ,,,シレトコ,シレトコハントウ,知床半島
 2	半島	半島	NOUN	名詞-普通名詞-一般	_	12	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ハントウ,半島,半島,半島,ハントー,,,ハントウ,シレトコハントウ,知床半島
@@ -3653,6 +3795,7 @@
 
 # newdoc id = test-s143
 # sent_id = test-s143
+# parallel_id = jagsd/test143
 # text = 企業経営者の、そして企業人一人ひとりの意識改革ではないだろうか。
 1	企業	企業	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キギョウ,企業,企業,企業,キギョー,,,キギョウ,キギョウケイエイシャ,企業経営者
 2	経営	経営	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケイエイ,経営,経営,経営,ケーエー,,,ケイエイ,キギョウケイエイシャ,企業経営者
@@ -3675,6 +3818,7 @@
 
 # newdoc id = test-s144
 # sent_id = test-s144
+# parallel_id = jagsd/test144
 # text = ※世帯ごとに保険料の上限が決まっている。
 1	※	※	SYM	補助記号-一般	_	10	dep	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=補助記号-一般|SpaceAfter=No|UnidicInfo=,※,※,※,,,,,,※
 2	世帯	世帯	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セタイ,世帯,世帯,世帯,セタイ,,,セタイ,セタイゴト,世帯毎
@@ -3692,6 +3836,7 @@
 
 # newdoc id = test-s145
 # sent_id = test-s145
+# parallel_id = jagsd/test145
 # text = 県では「風評被害を防ぐため」として店舗名を公表していない。
 1	県	県	NOUN	名詞-普通名詞-一般	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケン,県,県,県,ケン,,,ケン,ケン,県
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -3718,6 +3863,7 @@
 
 # newdoc id = test-s146
 # sent_id = test-s146
+# parallel_id = jagsd/test146
 # text = 先が気になるストーリー展開や、3人の演技に引き込まれてしまうこと間違いナシだ!
 1	先	先	NOUN	名詞-普通名詞-副詞可能	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サキ,先,先,先,サキ,,,サキ,サキ,先
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3745,6 +3891,7 @@
 
 # newdoc id = test-s149
 # sent_id = test-s149
+# parallel_id = jagsd/test149
 # text = 法案が上院を通過すれば、昨年12月に下院を通過した法案と統合する必要があり、アナリストによると、その時期は5月下旬になると見込まれている。
 1	法案	法案	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホウアン,法案,法案,法案,ホーアン,,,ホウアン,ホウアン,法案
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3793,6 +3940,7 @@
 
 # newdoc id = test-s150
 # sent_id = test-s150
+# parallel_id = jagsd/test150
 # text = 来場者は熱心に見入っていた。
 1	来場	来場	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ライジョウ,来場,来場,来場,ライジョー,,,ライジョウ,ライジョウシャ,来場者
 2	者	者	NOUN	接尾辞-名詞的-一般	_	6	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シャ,者,者,者,シャ,,,シャ,ライジョウシャ,来場者
@@ -3807,6 +3955,7 @@
 
 # newdoc id = test-s151
 # sent_id = test-s151
+# parallel_id = jagsd/test151
 # text = 入場無料。
 1	入場	入場	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニュウジョウ,入場,入場,入場,ニュージョー,,,ニュウジョウ,ニュウジョウムリョウ,入場無料
 2	無料	無料	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=I|BunsetuPositionType=ROOT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ムリョウ,無料,無料,無料,ムリョー,,,ムリョウ,ニュウジョウムリョウ,入場無料
@@ -3814,6 +3963,7 @@
 
 # newdoc id = test-s152
 # sent_id = test-s152
+# parallel_id = jagsd/test152
 # text = 当面は同省職員2人を派遣。
 1	当面	当面	NOUN	名詞-普通名詞-サ変可能	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウメン,当面,当面,当面,トーメン,,,トウメン,トウメン,当面
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -3826,6 +3976,7 @@
 
 # newdoc id = test-s153
 # sent_id = test-s153
+# parallel_id = jagsd/test153
 # text = 株式会社GCIキャピタルは、信頼できる情報をもとに本資料を作成しておりますが、正確性・完全性について株式会社GCIキャピタルが責任を負うものではありません。
 1	株式	株式	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=カブシキ,株式,株式,株式,カブシキ,,,カブシキ,カブシキガイシャジーシーアイキャピタル,株式会社GCIキャピタル
 2	会社	会社	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=カイシャ,会社,会社,会社,ガイシャ,,,カイシャ,カブシキガイシャジーシーアイキャピタル,株式会社GCIキャピタル
@@ -3875,6 +4026,7 @@
 
 # newdoc id = test-s154
 # sent_id = test-s154
+# parallel_id = jagsd/test154
 # text = そのあだ名の通り、女性を見ると口説き、襲おうとするリョウちゃん。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	あだ名	渾名	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アダナ,渾名,あだ名,あだ名,アダナ,,,アダナ,アダナ,渾名
@@ -3896,6 +4048,7 @@
 
 # newdoc id = test-s155
 # sent_id = test-s155
+# parallel_id = jagsd/test155
 # text = 男女が親交を深めやすいようにと、ピザ作り体験などを企画の柱にしたところ大好評となった。
 1	男女	男女	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダンジョ,男女,男女,男女,ダンジョ,,,ダンジョ,ダンジョ,男女
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -3928,6 +4081,7 @@
 
 # newdoc id = test-s156
 # sent_id = test-s156
+# parallel_id = jagsd/test156
 # text = 恵まれた身体能力を生かした守備はもちろん、闘争心をむき出しに前線へと駆け上がるプレーで相手を翻弄。
 1	恵まれ	恵まれる	VERB	動詞-一般-下一段-ラ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-下一段-ラ行|SpaceAfter=No|UnidicInfo=メグマレル,恵まれる,恵まれ,恵まれる,メグマレ,,,メグマレル,メグマレル,恵まれる
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-タ|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -3958,6 +4112,7 @@
 
 # newdoc id = test-s157
 # sent_id = test-s157
+# parallel_id = jagsd/test157
 # text = ベストアルバム『BAD TIMES』をリリースすることが明らかになりました!
 1	ベスト	ベスト	NOUN	名詞-普通名詞-形状詞可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ベスト,ベスト,ベスト,ベスト,ベスト,,,ベスト,ベストアルバム,ベストアルバム
 2	アルバム	アルバム	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アルバム,アルバム,アルバム,アルバム,アルバム,,,アルバム,ベストアルバム,ベストアルバム
@@ -3979,6 +4134,7 @@
 
 # newdoc id = test-s158
 # sent_id = test-s158
+# parallel_id = jagsd/test158
 # text = 震災を考慮して街頭運動が一部異例の選挙戦がスタートした。
 1	震災	震災	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンサイ,震災,震災,震災,シンサイ,,,シンサイ,シンサイ,震災
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4001,6 +4157,7 @@
 
 # newdoc id = test-s159
 # sent_id = test-s159
+# parallel_id = jagsd/test159
 # text = トッティは試合後に「この記録を誇りに思うが、ここで止まることはない」とコメント。
 1	トッティ	トッティ	PROPN	名詞-固有名詞-人名-一般	_	23	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=トッティ,トッティ,トッティ,トッティ,トッティ,,,トッティ,トッティ,トッティ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4029,6 +4186,7 @@
 
 # newdoc id = test-s160
 # sent_id = test-s160
+# parallel_id = jagsd/test160
 # text = 尾崎淳介校長は「水筒を持たせ、帽子をかぶるように指導していた。
 1	尾崎	尾崎	PROPN	名詞-固有名詞-人名-姓	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=オザキ,オザキ,尾崎,尾崎,オザキ,,,オザキ,オザキジュンスケコウチョウ,尾崎淳介校長
 2	淳介	淳介	PROPN	名詞-固有名詞-人名-名	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ジュンスケ,ジュンスケ,淳介,淳介,ジュンスケ,,,ジュンスケ,オザキジュンスケコウチョウ,尾崎淳介校長
@@ -4054,6 +4212,7 @@
 
 # newdoc id = test-s161
 # sent_id = test-s161
+# parallel_id = jagsd/test161
 # text = 自由で不思議でキュートな女の子、AKB48チームBのメンバーメンバー小林香菜。
 1	自由	自由	ADJ	名詞-普通名詞-形状詞可能	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ジユウ,自由,自由,自由,ジユー,,,ジユウ,ジユウ,自由
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -4076,6 +4235,7 @@
 
 # newdoc id = test-s162
 # sent_id = test-s162
+# parallel_id = jagsd/test162
 # text = 景観・社会・文化・報道・文化遺産・近代史写真等、豊富なジャンルでご対応!
 1	景観	景観	NOUN	名詞-普通名詞-一般	_	15	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケイカン,景観,景観,景観,ケーカン,,,ケイカン,ケイカンシャカイブンカホウドウブンカイサンキンダイシシャシントウ,景観・社会・文化・報道・文化遺産・近代史写真等
 2	・	・	SYM	補助記号-一般	_	15	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,ケイカンシャカイブンカホウドウブンカイサンキンダイシシャシントウ,景観・社会・文化・報道・文化遺産・近代史写真等
@@ -4103,6 +4263,7 @@
 
 # newdoc id = test-s163
 # sent_id = test-s163
+# parallel_id = jagsd/test163
 # text = 過去に記者会見で歌を歌った選手などがいたが競技外のパフォーマンスがどうであったとしても競技で結果を残せなければ何の意味もない事をトリノ以降、協会が選手に伝えきれていない。
 1	過去	過去	NOUN	名詞-普通名詞-副詞可能	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カコ,過去,過去,過去,カコ,,,カコ,カコ,過去
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4162,6 +4323,7 @@
 
 # newdoc id = test-s164
 # sent_id = test-s164
+# parallel_id = jagsd/test164
 # text = 18分以降、SAGAWAがボールをキープする時間が増え出し行くのだが、これはペースを握っているのではなく、前からのプレッシャーが厳しいため、一旦下げて後ろで回し、なんとか穴を探ろうとしたためにポゼッションする時間が増えただけのこと。
 1	18	18	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イチ,一八,18,18,イチハッ,,,イチハチ,イチハップンイコウ,18分以降
 2	分	分	NOUN	名詞-普通名詞-助数詞可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=フン,分,分,分,プン,,,フン,イチハップンイコウ,18分以降
@@ -4233,6 +4395,7 @@
 
 # newdoc id = test-s165
 # sent_id = test-s165
+# parallel_id = jagsd/test165
 # text = 通路を使って移動し、ホーム上の混雑を回避する。
 1	通路	通路	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ツウロ,通路,通路,通路,ツーロ,,,ツウロ,ツウロ,通路
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -4252,6 +4415,7 @@
 
 # newdoc id = test-s166
 # sent_id = test-s166
+# parallel_id = jagsd/test166
 # text = 2号機の西1・1キロにある西門付近で、17日午前0時半に毎時351・4マイクロシーベルトだった放射線量が、18日午前8時には270・5マイクロシーベルトに下がった。
 1	2	2	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニ,二,2,2,ニ,,,ニ,ニゴウキ,2号機
 2	号	号	NOUN	名詞-普通名詞-助数詞可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴウ,号,号,号,ゴー,,,ゴウ,ニゴウキ,2号機
@@ -4304,6 +4468,7 @@
 
 # newdoc id = test-s167
 # sent_id = test-s167
+# parallel_id = jagsd/test167
 # text = 簡単でおいしい上に、栄養のバランスがいいとなれば言うことなしです。
 1	簡単	簡単	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=カンタン,簡単,簡単,簡単,カンタン,,,カンタン,カンタン,簡単
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -4327,6 +4492,7 @@
 
 # newdoc id = test-s168
 # sent_id = test-s168
+# parallel_id = jagsd/test168
 # text = また、レートにより金額が多少左右されます。
 1	また	又	CCONJ	接続詞	_	9	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4344,6 +4510,7 @@
 
 # newdoc id = test-s169
 # sent_id = test-s169
+# parallel_id = jagsd/test169
 # text = 立件に消極的だったという。
 1	立件	立件	NOUN	名詞-普通名詞-サ変可能	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=リッケン,立件,立件,立件,リッケン,,,リッケン,リッケン,立件
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -4357,6 +4524,7 @@
 
 # newdoc id = test-s170
 # sent_id = test-s170
+# parallel_id = jagsd/test170
 # text = わが外相が「重要な進展だ」と胸を張っているように見えたのは、きっと気のせいだ。
 1	わが	我が	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ワガ,我が,わが,わが,ワガ,,,ワガ,ワガ,我が
 2	外相	外相	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ガイショウ,外相,外相,外相,ガイショー,,,ガイショウ,ガイショウ,外相
@@ -4389,6 +4557,7 @@
 
 # newdoc id = test-s171
 # sent_id = test-s171
+# parallel_id = jagsd/test171
 # text = オバマ大統領は、雇用対策の恩恵を受ける教師や警官、建設労働者らを背に演説に臨み、「この法案が、人々を職場に戻していくことにつながる」とアピール。
 1	オバマ	オバマ	PROPN	名詞-固有名詞-人名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=オバマ,オバマ,オバマ,オバマ,オバマ,,,オバマ,オバマダイトウリョウ,オバマ大統領
 2	大統領	大統領	NOUN	名詞-普通名詞-一般	_	24	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ダイトウリョウ,大統領,大統領,大統領,ダイトーリョー,,,ダイトウリョウ,オバマダイトウリョウ,オバマ大統領
@@ -4437,6 +4606,7 @@
 
 # newdoc id = test-s172
 # sent_id = test-s172
+# parallel_id = jagsd/test172
 # text = オーストラリア、カナダ、メキシコでも、それぞれの国の労働者が転職先を見つけることができるとの回答が高いことがわかりました
 1	オーストラリア	オーストラリア	PROPN	名詞-固有名詞-地名-国	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=オーストラリア,オーストラリア,オーストラリア,オーストラリア,オーストラリア,,,オーストラリア,オーストラリア,オーストラリア
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4473,6 +4643,7 @@
 
 # newdoc id = test-s173
 # sent_id = test-s173
+# parallel_id = jagsd/test173
 # text = 橋下知事は立候補を明言こそしなかったが、「大都市、大阪の市長に平松市長はふさわしくない。
 1	橋下	橋下	PROPN	名詞-固有名詞-人名-姓	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=ハシモト,ハシモト,橋下,橋下,ハシモト,,,ハシモト,ハシモトチジ,橋下知事
 2	知事	知事	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=チジ,知事,知事,知事,チジ,,,チジ,ハシモトチジ,橋下知事
@@ -4504,6 +4675,7 @@
 
 # newdoc id = test-s174
 # sent_id = test-s174
+# parallel_id = jagsd/test174
 # text = 米中戦略・経済対話初日の米側は中国の反体制派への弾圧を厳しく批判したが、世界の経済成長については協調的な姿勢を示した。
 1	米中	米中	NOUN	名詞-普通名詞-一般	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ベイチュウ,米中,米中,米中,ベーチュー,,,ベイチュウ,ベイチュウセンリャクケイザイタイワショニチ,米中戦略・経済対話初日
 2	戦略	戦略	NOUN	名詞-普通名詞-一般	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センリャク,戦略,戦略,戦略,センリャク,,,センリャク,ベイチュウセンリャクケイザイタイワショニチ,米中戦略・経済対話初日
@@ -4548,6 +4720,7 @@
 
 # newdoc id = test-s175
 # sent_id = test-s175
+# parallel_id = jagsd/test175
 # text = ジャカルタの街中で自転車を利用する人が増えたように思う。
 1	ジャカルタ	ジャカルタ	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ジャカルタ,ジャカルタ,ジャカルタ,ジャカルタ,ジャカルタ,,,ジャカルタ,ジャカルタ,ジャカルタ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4569,6 +4742,7 @@
 
 # newdoc id = test-s176
 # sent_id = test-s176
+# parallel_id = jagsd/test176
 # text = サイトの新しい楽しみ方「屋上会議室」好評公開中!
 1	サイト	サイト	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サイト,サイト,サイト,サイト,サイト,,,サイト,サイト,サイト
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4587,6 +4761,7 @@
 
 # newdoc id = test-s177
 # sent_id = test-s177
+# parallel_id = jagsd/test177
 # text = その名の通り、スライド全面にグラフィックを配置。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	名	名	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナ,名,名,名,ナ,,,ナ,ナ,名
@@ -4603,6 +4778,7 @@
 
 # newdoc id = test-s178
 # sent_id = test-s178
+# parallel_id = jagsd/test178
 # text = 高校時代の同級生とあって合宿中も、不安を打ち明け合っているという。
 1	高校	高校	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウコウ,高校,高校,高校,コーコー,,,コウコウ,コウコウジダイ,高校時代
 2	時代	時代	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジダイ,時代,時代,時代,ジダイ,,,ジダイ,コウコウジダイ,高校時代
@@ -4628,6 +4804,7 @@
 
 # newdoc id = test-s179
 # sent_id = test-s179
+# parallel_id = jagsd/test179
 # text = あるいは、試練に挑もうとしない逃避癖だ。
 1	あるいは	或いは	CCONJ	接続詞	_	10	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=アルイハ,或いは,あるいは,あるいは,アルイワ,,,アルイハ,アルイハ,或いは
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -4644,6 +4821,7 @@
 
 # newdoc id = test-s180
 # sent_id = test-s180
+# parallel_id = jagsd/test180
 # text = イランが、IEF国際エネルギー・フォーラム実行委員会の常任メンバー国に選出されました。
 1	イラン	イラン	PROPN	名詞-固有名詞-地名-国	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=イラン,イラン,イラン,イラン,イラン,,,イラン,イラン,イラン
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -4670,6 +4848,7 @@
 
 # newdoc id = test-s181
 # sent_id = test-s181
+# parallel_id = jagsd/test181
 # text = 信号変換効率を向上するとともに、超低域の歪みを改善し、低域から高域まで、すぐれた周波数特性を実現している。
 1	信号	信号	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンゴウ,信号,信号,信号,シンゴー,,,シンゴウ,シンゴウヘンカンコウリツ,信号変換効率
 2	変換	変換	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヘンカン,変換,変換,変換,ヘンカン,,,ヘンカン,シンゴウヘンカンコウリツ,信号変換効率
@@ -4708,6 +4887,7 @@
 
 # newdoc id = test-s182
 # sent_id = test-s182
+# parallel_id = jagsd/test182
 # text = 初期投資のいくらか全ての損失を被る可能性が存在します、
 1	初期	初期	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショキ,初期,初期,初期,ショキ,,,ショキ,ショキトウシ,初期投資
 2	投資	投資	NOUN	名詞-普通名詞-サ変可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウシ,投資,投資,投資,トーシ,,,トウシ,ショキトウシ,初期投資
@@ -4729,6 +4909,7 @@
 
 # newdoc id = test-s183
 # sent_id = test-s183
+# parallel_id = jagsd/test183
 # text = 最初の仕切りで芳東に待ったをかけられた宝智山は、仕切り直しの立ち合いで得意の右四つとなり左上手を取ると、相手に構うことなく前に出てそのまま寄り倒した。
 1	最初	最初	NOUN	名詞-普通名詞-副詞可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サイショ,最初,最初,最初,サイショ,,,サイショ,サイショ,最初
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -4779,6 +4960,7 @@
 
 # newdoc id = test-s184
 # sent_id = test-s184
+# parallel_id = jagsd/test184
 # text = 父から「おまえが決意して、そこまでやるなら応援する」と思いもよらない言葉で激励された。
 1	父	父	NOUN	名詞-普通名詞-一般	_	24	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チチ,父,父,父,チチ,,,チチ,チチ,父
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -4811,6 +4993,7 @@
 
 # newdoc id = test-s185
 # sent_id = test-s185
+# parallel_id = jagsd/test185
 # text = 西宮市は活動を大規模災害に限っているため、日常的に活動する機能別消防団員は県内初。
 1	西宮	西宮	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ニシノミヤ,ニシノミヤ,西宮,西宮,ニシノミヤ,,,ニシノミヤ,ニシノミヤシ,西宮市
 2	市	市	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=シ,市,市,市,シ,,,シ,ニシノミヤシ,西宮市
@@ -4843,6 +5026,7 @@
 
 # newdoc id = test-s186
 # sent_id = test-s186
+# parallel_id = jagsd/test186
 # text = 東中本運動場まで徒歩5分一日600円/5台
 1	東	東	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒガシ,東,東,東,ヒガシ,,,ヒガシ,ヒガシナカモトウンドウジョウ,東中本運動場
 2	中本	中本	PROPN	名詞-固有名詞-地名-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナカモト,ナカモト,中本,中本,ナカモト,,,ナカモト,ヒガシナカモトウンドウジョウ,東中本運動場
@@ -4862,6 +5046,7 @@
 
 # newdoc id = test-s187
 # sent_id = test-s187
+# parallel_id = jagsd/test187
 # text = って言ってる年齢不詳?
 1	って	って	PART	助詞-副助詞	_	2	mark	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ッテ,って,って,って,ッテ,,,ッテ,ツウ,つう
 2	言っ	言う	VERB	動詞-一般-五段-ワア行	_	5	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-ワア行|SpaceAfter=No|UnidicInfo=イウ,言う,言っ,言う,イッ,,,イウ,イウ,言う
@@ -4872,6 +5057,7 @@
 
 # newdoc id = test-s188
 # sent_id = test-s188
+# parallel_id = jagsd/test188
 # text = キレイでオシャレな店内はずっといてもいいぐらいですね。
 1	キレイ	奇麗	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=キレイ,奇麗,キレイ,キレイ,キレー,,,キレイ,キレイ,奇麗
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -4891,6 +5077,7 @@
 
 # newdoc id = test-s189
 # sent_id = test-s189
+# parallel_id = jagsd/test189
 # text = 自分は希望スタイルをいつも複数抱えて来店しますが、センスの良いスタッフの意見が役に立っていつも満足のいく仕上がりを施してくださいます。
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4933,6 +5120,7 @@
 
 # newdoc id = test-s190
 # sent_id = test-s190
+# parallel_id = jagsd/test190
 # text = あれじゃ客は来ないね、
 1	あれ	彼れ	PRON	代名詞	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=アレ,彼れ,あれ,あれ,アレ,,,アレ,アレ,彼れ
 2	じゃ	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,じゃ,じゃ,ジャ,,,ジャ,デ,で
@@ -4945,6 +5133,7 @@
 
 # newdoc id = test-s191
 # sent_id = test-s191
+# parallel_id = jagsd/test191
 # text = 診察は予約制なのに1時間まちはざらです。
 1	診察	診察	NOUN	名詞-普通名詞-サ変可能	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンサツ,診察,診察,診察,シンサツ,,,シンサツ,シンサツ,診察
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -4963,6 +5152,7 @@
 
 # newdoc id = test-s192
 # sent_id = test-s192
+# parallel_id = jagsd/test192
 # text = “シールド工法”が良くわかります。
 1	“	“	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,“,“,“,,,,,,“
 2	シールド	シールド	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シールド,シールド,シールド,シールド,シールド,,,シールド,シールドコウホウ,シールド工法
@@ -4976,6 +5166,7 @@
 
 # newdoc id = test-s193
 # sent_id = test-s193
+# parallel_id = jagsd/test193
 # text = エステは受けたことが無いので相場はわかりませんでしたが、まぁ、これなら妥当かな、という感じでした。
 1	エステ	エステ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エステ,エステ,エステ,エステ,エステ,,,エステ,エステ,エステ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5012,6 +5203,7 @@
 
 # newdoc id = test-s194
 # sent_id = test-s194
+# parallel_id = jagsd/test194
 # text = 父には90分コースをセレクトしましたが、新規価格ということで少しお得になっていました。
 1	父	父	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チチ,父,父,父,チチ,,,チチ,チチ,父
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -5045,6 +5237,7 @@
 
 # newdoc id = test-s195
 # sent_id = test-s195
+# parallel_id = jagsd/test195
 # text = 友人の紹介で東京の出張マッサージを利用。
 1	友人	友人	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ユウジン,友人,友人,友人,ユージン,,,ユウジン,ユウジン,友人
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5060,6 +5253,7 @@
 
 # newdoc id = test-s196
 # sent_id = test-s196
+# parallel_id = jagsd/test196
 # text = スタッフがフレンドリー。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフ,スタッフ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5068,6 +5262,7 @@
 
 # newdoc id = test-s197
 # sent_id = test-s197
+# parallel_id = jagsd/test197
 # text = お皿は全て重ねてたのですが、しばらくすると女性の従業員が来て、こちらのトロ刺身のお皿はお取りになられましたか?
 1	お	御	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オサラ,御皿
 2	皿	皿	NOUN	名詞-普通名詞-助数詞可能	_	5	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サラ,皿,皿,皿,サラ,,,サラ,オサラ,御皿
@@ -5111,6 +5306,7 @@
 
 # newdoc id = test-s198
 # sent_id = test-s198
+# parallel_id = jagsd/test198
 # text = 営業時間は朝9時~夜7時までみたいですが、人気のあるパンはすぐなくなってしまいます。
 1	営業	営業	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エイギョウ,営業,営業,営業,エーギョー,,,エイギョウ,エイギョウジカン,営業時間
 2	時間	時間	NOUN	名詞-普通名詞-助数詞可能	_	10	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジカン,時間,時間,時間,ジカン,,,ジカン,エイギョウジカン,営業時間
@@ -5141,6 +5337,7 @@
 
 # newdoc id = test-s199
 # sent_id = test-s199
+# parallel_id = jagsd/test199
 # text = 大門側から高野山に入って最初の信号にある出光興産系のガソリンスタンド。
 1	大門	大門	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダイモン,大門,大門,大門,ダイモン,,,ダイモン,ダイモンガワ,大門側
 2	側	側	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ガワ,側,側,側,ガワ,,,ガワ,ダイモンガワ,大門側
@@ -5165,6 +5362,7 @@
 
 # newdoc id = test-s200
 # sent_id = test-s200
+# parallel_id = jagsd/test200
 # text = テレビにて、こちらの店を知りましたが、こだわりの店と認識していたので正直がっかりさせられました。
 1	テレビ	テレビ	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テレビ,テレビ,テレビ,テレビ,テレビ,,,テレビ,テレビ,テレビ
 2	にて	にて	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニテ,にて,にて,にて,ニテ,,,ニテ,ニテ,にて
@@ -5200,6 +5398,7 @@
 
 # newdoc id = test-s201
 # sent_id = test-s201
+# parallel_id = jagsd/test201
 # text = アアルトさんのコーヒー豆を使ったコーヒーは文句のつけようなし!
 1	アアルト	アアルト	PROPN	名詞-固有名詞-人名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=アールト,アールト,アアルト,アアルト,アールト,,,アールト,アールトサン,アアルトさん
 2	さん	さん	NOUN	接尾辞-名詞的-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=サン,さん,さん,さん,サン,,,サン,アールトサン,アアルトさん
@@ -5220,6 +5419,7 @@
 
 # newdoc id = test-s202
 # sent_id = test-s202
+# parallel_id = jagsd/test202
 # text = 値段も普通くらいかな。
 1	値段	値段	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ネダン,値段,値段,値段,ネダン,,,ネダン,ネダン,値段
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -5231,6 +5431,7 @@
 
 # newdoc id = test-s203
 # sent_id = test-s203
+# parallel_id = jagsd/test203
 # text = いつも割りと混んでる。
 1	いつ	何時	PRON	代名詞	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=イツ,何時,いつ,いつ,イツ,,,イツ,イツ,何時
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -5241,6 +5442,7 @@
 
 # newdoc id = test-s204
 # sent_id = test-s204
+# parallel_id = jagsd/test204
 # text = 宴会が入って忙しかったのかも知れないが、接客は最悪、味も最低、刺身の盛り合わせは水っぽく、町のスーパーで売っている最低ランクの刺身と同じ味。
 1	宴会	宴会	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エンカイ,宴会,宴会,宴会,エンカイ,,,エンカイ,エンカイ,宴会
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -5288,6 +5490,7 @@
 
 # newdoc id = test-s205
 # sent_id = test-s205
+# parallel_id = jagsd/test205
 # text = 夜は5時に行くのが1番です。
 1	夜	夜	NOUN	名詞-普通名詞-副詞可能	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨル,夜,夜,夜,ヨル,,,ヨル,ヨル,夜
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5303,6 +5506,7 @@
 
 # newdoc id = test-s206
 # sent_id = test-s206
+# parallel_id = jagsd/test206
 # text = 治療やケアの方も素晴らしく、待合室もここが歯医者だと忘れてしまうくらい立派です。
 1	治療	治療	NOUN	名詞-普通名詞-サ変可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チリョウ,治療,治療,治療,チリョー,,,チリョウ,チリョウ,治療
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -5331,6 +5535,7 @@
 
 # newdoc id = test-s207
 # sent_id = test-s207
+# parallel_id = jagsd/test207
 # text = 料理も美味しいし、女将・スタッフの皆さんよい感じでしたよ!
 1	料理	料理	NOUN	名詞-普通名詞-サ変可能	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=リョウリ,料理,料理,料理,リョーリ,,,リョウリ,リョウリ,料理
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -5352,6 +5557,7 @@
 
 # newdoc id = test-s211
 # sent_id = test-s211
+# parallel_id = jagsd/test211
 # text = この様な担当者の姿勢、とても良いと思います。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	様	様	NOUN	形状詞-助動詞語幹	_	7	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-助動詞語幹|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=ヨウ,様,様,様,ヨー,,,ヨウ,ヨウ,様
@@ -5370,6 +5576,7 @@
 
 # newdoc id = test-s212
 # sent_id = test-s212
+# parallel_id = jagsd/test212
 # text = 他社と比べても初めての見積もりの内容が非常に具体的でイメージがわきやすく好印象でした。
 1	他社	他社	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タシャ,他社,他社,他社,タシャ,,,タシャ,タシャ,他社
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -5399,6 +5606,7 @@
 
 # newdoc id = test-s213
 # sent_id = test-s213
+# parallel_id = jagsd/test213
 # text = 持ってきてくれるのはいいのですが、他のメニューは食べ終わってしまって「おあずけ」状態です。
 1	持っ	持つ	VERB	動詞-一般-五段-タ行	_	8	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-タ行|SpaceAfter=No|UnidicInfo=モツ,持つ,持っ,持つ,モッ,,,モツ,モツ,持つ
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助動詞-五段-カ行|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テク,てく
@@ -5431,6 +5639,7 @@
 
 # newdoc id = test-s214
 # sent_id = test-s214
+# parallel_id = jagsd/test214
 # text = また、この店は、土日になるとドライブスルー渋滞ができます。
 1	また	又	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -5452,6 +5661,7 @@
 
 # newdoc id = test-s215
 # sent_id = test-s215
+# parallel_id = jagsd/test215
 # text = 料理は美味しい、雰囲気も良い、なによりお酒が美味しい。
 1	料理	料理	NOUN	名詞-普通名詞-サ変可能	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=リョウリ,料理,料理,料理,リョーリ,,,リョウリ,リョウリ,料理
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5471,6 +5681,7 @@
 
 # newdoc id = test-s216
 # sent_id = test-s216
+# parallel_id = jagsd/test216
 # text = 最近かなり混んで来ましたが先生は相変わらずマイペースでしっかり診療してくれるので予約が遅くなっても不満はありません。
 1	最近	最近	ADV	名詞-普通名詞-副詞可能	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=サイキン,最近,最近,最近,サイキン,,,サイキン,サイキン,最近
 2	かなり	可成	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=カナリ,可成,かなり,かなり,カナリ,,,カナリ,カナリ,可成
@@ -5510,6 +5721,7 @@
 
 # newdoc id = test-s217
 # sent_id = test-s217
+# parallel_id = jagsd/test217
 # text = 参ったなぁ、と途方にくれた時ふと最初に「あれではないよな」と思っていた不動明王の像があるお墓。
 1	参っ	参る	VERB	動詞-非自立可能-五段-ラ行	_	8	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-ラ行|SpaceAfter=No|UnidicInfo=マイル,参る,参っ,参る,マイッ,,,マイル,マイル,参る
 2	た	た	AUX	助動詞-助動詞-タ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-タ|SpaceAfter=No|UnidicInfo=タ,た,た,た,タ,,,タ,タ,た
@@ -5549,6 +5761,7 @@
 
 # newdoc id = test-s218
 # sent_id = test-s218
+# parallel_id = jagsd/test218
 # text = バッティングセンターとビリヤード台もあって、仕出しをとれる会議室もあり、小さいながらも施設機能は充実してます。
 1	バッティング	バッティング	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バッティング,バッティング,バッティング,バッティング,バッティング,,,バッティング,バッティングセンター,バッティングセンター
 2	センター	センター	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センター,センター,センター,センター,センター,,,センター,バッティングセンター,バッティングセンター
@@ -5581,6 +5794,7 @@
 
 # newdoc id = test-s219
 # sent_id = test-s219
+# parallel_id = jagsd/test219
 # text = 子供お祝い返しに買ったロールケーキがカビていたので、本当に怒りしんとうでした
 1	子供	子供	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コドモ,子供,子供,子供,コドモ,,,コドモ,コドモオイワイガエシ,子供御祝い返し
 2	お	御	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,コドモオイワイガエシ,子供御祝い返し
@@ -5607,6 +5821,7 @@
 
 # newdoc id = test-s220
 # sent_id = test-s220
+# parallel_id = jagsd/test220
 # text = すごく親身にお世話してくれました。
 1	すごく	凄い	ADJ	形容詞-一般-形容詞	_	2	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=スゴイ,凄い,すごく,すごい,スゴク,,,スゴイ,スゴイ,凄い
 2	親身	親身	ADJ	形状詞-一般	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=シンミ,親身,親身,親身,シンミ,,,シンミ,シンミ,親身
@@ -5622,6 +5837,7 @@
 
 # newdoc id = test-s221
 # sent_id = test-s221
+# parallel_id = jagsd/test221
 # text = 最近出来た新しい産婦人科と悩みましたが、こちらの病院を選び正解だったと感じてます。
 1	最近	最近	ADV	名詞-普通名詞-副詞可能	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=サイキン,最近,最近,最近,サイキン,,,サイキン,サイキン,最近
 2	出来	出来る	VERB	動詞-非自立可能-上一段-カ行	_	7	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-上一段-カ行|PrevUDLemma=できる|SpaceAfter=No|UnidicInfo=デキル,出来る,出来,出来る,デキ,,,デキル,デキル,出来る
@@ -5652,6 +5868,7 @@
 
 # newdoc id = test-s222
 # sent_id = test-s222
+# parallel_id = jagsd/test222
 # text = その時からのだから?
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	時	時	NOUN	名詞-普通名詞-副詞可能	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トキ,時,時,時,トキ,,,トキ,トキ,時
@@ -5663,6 +5880,7 @@
 
 # newdoc id = test-s223
 # sent_id = test-s223
+# parallel_id = jagsd/test223
 # text = 美味しいおせんべいの他、ワッフルやゼリーなどもオススメです。
 1	美味しい	美味しい	ADJ	形容詞-一般-形容詞	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=オイシイ,美味しい,美味しい,美味しい,オイシー,,,オイシイ,オイシイ,美味しい
 2	お	御	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オセンベイ,御煎餅
@@ -5682,6 +5900,7 @@
 
 # newdoc id = test-s224
 # sent_id = test-s224
+# parallel_id = jagsd/test224
 # text = ずっとコンプレックスだったので、キレイにしていただけて本当に良かったです。
 1	ずっと	ずっと	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ズット,ずっと,ずっと,ずっと,ズット,,,ズット,ズット,ずっと
 2	コンプレックス	コンプレックス	NOUN	名詞-普通名詞-一般	_	16	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コンプレックス,コンプレックス,コンプレックス,コンプレックス,コンプレックス,,,コンプレックス,コンプレックス,コンプレックス
@@ -5705,6 +5924,7 @@
 
 # newdoc id = test-s226
 # sent_id = test-s226
+# parallel_id = jagsd/test226
 # text = とりあえず生ビールから始め、華のれんさんのサイトで気になってた「ばくだん」という名物料理でまずは一杯。
 1	とりあえず	取り敢えず	ADV	副詞	_	5	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=トリアエズ,取り敢えず,とりあえず,とりあえず,トリアエズ,,,トリアエズ,トリアエズ,取り敢えず
 2	生	生	NOUN	名詞-普通名詞-形状詞可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナマ,生,生,生,ナマ,,,ナマ,ナマビール,生ビール
@@ -5738,6 +5958,7 @@
 
 # newdoc id = test-s227
 # sent_id = test-s227
+# parallel_id = jagsd/test227
 # text = Tacoは1つ3ドルぐらい。
 1	Taco	Taco	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タコ,Taco,Taco,Taco,タコ,,,タコ,タコ,Taco
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5750,6 +5971,7 @@
 
 # newdoc id = test-s228
 # sent_id = test-s228
+# parallel_id = jagsd/test228
 # text = ゼクシィを見て、いろいろなお店に体験に行きましたが、このお店が圧倒的によかったので、通うことにしました。
 1	ゼクシィ	ゼクシィ	PROPN	名詞-固有名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ゼクシー,ゼクシー,ゼクシィ,ゼクシィ,ゼクシー,,,ゼクシー,ゼクシー,ゼクシー
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -5790,6 +6012,7 @@
 
 # newdoc id = test-s229
 # sent_id = test-s229
+# parallel_id = jagsd/test229
 # text = 私はあまりエステにお金をかけれないと思い色々なエステサロンに相談にすごく親身になって下さり他のエステさんより安心できました。
 1	私	私	PRON	代名詞	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -5829,6 +6052,7 @@
 
 # newdoc id = test-s230
 # sent_id = test-s230
+# parallel_id = jagsd/test230
 # text = 着付けや和装ヘアスタイルが得意。
 1	着付け	着付け	NOUN	名詞-普通名詞-サ変可能	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キツケ,着付け,着付け,着付け,キツケ,,,キツケ,キツケ,着付け
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -5841,6 +6065,7 @@
 
 # newdoc id = test-s231
 # sent_id = test-s231
+# parallel_id = jagsd/test231
 # text = スタッフの皆さんが笑顔で接してくれて、全然緊張することなく過ごせました。
 1	スタッフ	スタッフ	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スタッフ,スタッフ,スタッフ,スタッフ,スタッフ,,,スタッフ,スタッフ,スタッフ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5866,6 +6091,7 @@
 
 # newdoc id = test-s232
 # sent_id = test-s232
+# parallel_id = jagsd/test232
 # text = デスクワークで固まった肩や背中を、アロママッサージで気持ちよくほぐしていただいて助かります。
 1	デスク	デスク	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=デスク,デスク,デスク,デスク,デスク,,,デスク,デスクワーク,デスクワーク
 2	ワーク	ワーク	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ワーク,ワーク,ワーク,ワーク,ワーク,,,ワーク,デスクワーク,デスクワーク
@@ -5892,6 +6118,7 @@
 
 # newdoc id = test-s233
 # sent_id = test-s233
+# parallel_id = jagsd/test233
 # text = 最後まで熱々で食べれる温度管理白馬近辺でラーメンと言ったらここですかね。
 1	最後	最後	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サイゴ,最後,最後,最後,サイゴ,,,サイゴ,サイゴ,最後
 2	まで	まで	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=マデ,まで,まで,まで,マデ,,,マデ,マデ,まで
@@ -5915,6 +6142,7 @@
 
 # newdoc id = test-s234
 # sent_id = test-s234
+# parallel_id = jagsd/test234
 # text = 声もほとんど筒抜け状態であった。
 1	声	声	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コエ,声,声,声,コエ,,,コエ,コエ,声
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -5928,6 +6156,7 @@
 
 # newdoc id = test-s235
 # sent_id = test-s235
+# parallel_id = jagsd/test235
 # text = 隠れ家居酒屋という名前にぴったり。
 1	隠れ家	隠れ家	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カクレガ,隠れ家,隠れ家,隠れ家,カクレガ,,,カクレガ,カクレガイザカヤ,隠れ家居酒屋
 2	居酒屋	居酒屋	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イザカヤ,居酒屋,居酒屋,居酒屋,イザカヤ,,,イザカヤ,カクレガイザカヤ,隠れ家居酒屋
@@ -5940,6 +6169,7 @@
 
 # newdoc id = test-s236
 # sent_id = test-s236
+# parallel_id = jagsd/test236
 # text = 私たちの場合、金銭に絡んだ多重債務の処理等たくさん手がけているとのことで安心して相談できました。
 1	私	私	PRON	代名詞	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシタチ,私達
 2	たち	達	NOUN	接尾辞-名詞的-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=タチ,達,たち,たち,タチ,,,タチ,ワタシタチ,私達
@@ -5974,6 +6204,7 @@
 
 # newdoc id = test-s237
 # sent_id = test-s237
+# parallel_id = jagsd/test237
 # text = 在庫の様子がよくわからないけど、デパートの中なのでたぶん小さい。
 1	在庫	在庫	NOUN	名詞-普通名詞-サ変可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ザイコ,在庫,在庫,在庫,ザイコ,,,ザイコ,ザイコ,在庫
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -5996,6 +6227,7 @@
 
 # newdoc id = test-s238
 # sent_id = test-s238
+# parallel_id = jagsd/test238
 # text = 若いお客さんよりそれ相応の年代のお客が多く、落ち着いて飲めるBarです。
 1	若い	若い	ADJ	形容詞-一般-形容詞	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=ワカイ,若い,若い,若い,ワカイ,,,ワカイ,ワカイ,若い
 2	お	御	NOUN	接頭辞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オキャクサン,御客さん
@@ -6021,6 +6253,7 @@
 
 # newdoc id = test-s239
 # sent_id = test-s239
+# parallel_id = jagsd/test239
 # text = 出入り口の交差点はもともと歩行者や自転車が多いので、かなり混雑しています。
 1	出入り	出入り	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=デイリ,出入り,出入り,出入り,デイリ,,,デイリ,デイリグチ,出入り口
 2	口	口	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=クチ,口,口,口,グチ,,,クチ,デイリグチ,出入り口
@@ -6049,6 +6282,7 @@
 
 # newdoc id = test-s240
 # sent_id = test-s240
+# parallel_id = jagsd/test240
 # text = 食べきれないくらい出てきました。
 1	食べ	食べる	VERB	動詞-一般-下一段-バ行	_	5	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-下一段-ラ行|SpaceAfter=No|UnidicInfo=タベル,食べる,食べ,食べる,タベ,,,タベル,タベキレル,食べ切れる
 2	きれ	切る	VERB	動詞-非自立可能-下一段-ラ行	_	1	advcl	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=動詞-一般-下一段-ラ行|SpaceAfter=No|UnidicInfo=キル,切る,きれ,きれる,キレ,,,キレル,タベキレル,食べ切れる
@@ -6063,6 +6297,7 @@
 
 # newdoc id = test-s241
 # sent_id = test-s241
+# parallel_id = jagsd/test241
 # text = 小さいお子さんがいるお母さんには最高のお店です。
 1	小さい	小さい	ADJ	形容詞-一般-形容詞	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=チイサイ,小さい,小さい,小さい,チーサイ,,,チイサイ,チイサイ,小さい
 2	お	御	NOUN	接頭辞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オコサン,御子さん
@@ -6084,6 +6319,7 @@
 
 # newdoc id = test-s243
 # sent_id = test-s243
+# parallel_id = jagsd/test243
 # text = 値段は間違えてぼられるし刺身は最悪でした
 1	値段	値段	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ネダン,値段,値段,値段,ネダン,,,ネダン,ネダン,値段
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6100,6 +6336,7 @@
 
 # newdoc id = test-s244
 # sent_id = test-s244
+# parallel_id = jagsd/test244
 # text = ソフトバンク直営店より高く売っています
 1	ソフト	ソフト	NOUN	名詞-普通名詞-形状詞可能	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ソフト,ソフト,ソフト,ソフト,ソフト,,,ソフト,ソフトバンクチョクエイテン,ソフトバンク直営店
 2	バンク	バンク	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バンク,バンク,バンク,バンク,バンク,,,バンク,ソフトバンクチョクエイテン,ソフトバンク直営店
@@ -6114,6 +6351,7 @@
 
 # newdoc id = test-s245
 # sent_id = test-s245
+# parallel_id = jagsd/test245
 # text = しかしこのフロントの女性は、結局エレベーターに乗れずに階段を下りてきた私たちに向かって、「タクシーがずーーーっと待ってますので、急いでください」と言ってきました。
 1	しかし	然し	CCONJ	接続詞	_	41	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	この	此の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
@@ -6164,6 +6402,7 @@
 
 # newdoc id = test-s246
 # sent_id = test-s246
+# parallel_id = jagsd/test246
 # text = ビンや缶に入っているのは糀が死んでいるのですね。
 1	ビン	瓶	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ビン,瓶,ビン,ビン,ビン,,,ビン,ビン,瓶
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -6186,6 +6425,7 @@
 
 # newdoc id = test-s247
 # sent_id = test-s247
+# parallel_id = jagsd/test247
 # text = 大きなお店は苦手なので私にとってはアットホームな感じで楽しい時間を過ごすことができ大満足です。
 1	大きな	大きな	ADJ	連体詞	_	3	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=オオキナ,大きな,大きな,大きな,オーキナ,,,オオキナ,オオキナ,大きな
 2	お	御	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オミセ,御店
@@ -6219,6 +6459,7 @@
 
 # newdoc id = test-s249
 # sent_id = test-s249
+# parallel_id = jagsd/test249
 # text = まだまだ聞きとれない単語もいっぱいですが、最近は英語を聞いてもビクッと構えることなくどんどん質問しちゃってます、
 1	まだまだ	未だ未だ	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=マダマダ,未だ未だ,まだまだ,まだまだ,マダマダ,,,マダマダ,マダマダ,未だ未だ
 2	聞きとれ	聞き取る	VERB	動詞-一般-下一段-ラ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-下一段-ラ行|SpaceAfter=No|UnidicInfo=キキトル,聞き取る,聞きとれ,聞きとれる,キキトレ,,,キキトレル,キキトレル,聞き取れる
@@ -6251,6 +6492,7 @@
 
 # newdoc id = test-s250
 # sent_id = test-s250
+# parallel_id = jagsd/test250
 # text = レッスンが楽しみで、何をしても長続きしない私でも、週1回きっちり通えています。
 1	レッスン	レッスン	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=レッスン,レッスン,レッスン,レッスン,レッスン,,,レッスン,レッスン,レッスン
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -6281,6 +6523,7 @@
 
 # newdoc id = test-s251
 # sent_id = test-s251
+# parallel_id = jagsd/test251
 # text = また問診についてですが、他所受診にて原因不明のままの痛みについてしばらくの間レントゲンではなくMRI検査を検討していた為、やはり検査手段について医師と相談したかったです。
 1	また	又	CCONJ	接続詞	_	46	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	問診	問診	NOUN	名詞-普通名詞-サ変可能	_	46	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=モンシン,問診,問診,問診,モンシン,,,モンシン,モンシン,問診
@@ -6336,6 +6579,7 @@
 
 # newdoc id = test-s252
 # sent_id = test-s252
+# parallel_id = jagsd/test252
 # text = なかなか、女性一人で、ゆっくり、休める宿は少ない、
 1	なかなか	中々	ADV	副詞	_	12	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ナカナカ,中々,なかなか,なかなか,ナカナカ,,,ナカナカ,ナカナカ,中々
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6353,6 +6597,7 @@
 
 # newdoc id = test-s253
 # sent_id = test-s253
+# parallel_id = jagsd/test253
 # text = 高松以外のホテルエリアワンを利用したことがあり、その際にサービス、ホテルの施設などが気に入って、今回も利用させていただくことにしました。
 1	高松	高松	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タカマツ,タカマツ,高松,高松,タカマツ,,,タカマツ,タカマツイガイ,高松以外
 2	以外	以外	NOUN	名詞-普通名詞-副詞可能	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イガイ,以外,以外,以外,イガイ,,,イガイ,タカマツイガイ,高松以外
@@ -6399,6 +6644,7 @@
 
 # newdoc id = test-s254
 # sent_id = test-s254
+# parallel_id = jagsd/test254
 # text = 色々な飲食店が乱立する中、老舗の安定感と手軽さを兼ね揃えています。
 1	色々	色々	ADJ	形状詞-一般	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=イロイロ,色々,色々,色々,イロイロ,,,イロイロ,イロイロ,色々
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -6425,6 +6671,7 @@
 
 # newdoc id = test-s256
 # sent_id = test-s256
+# parallel_id = jagsd/test256
 # text = ただ、自分で同じような柔軟やマッサージをしてみてもうまくできないようだ。
 1	ただ	唯	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=タダ,唯,ただ,ただ,タダ,,,タダ,タダ,唯
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -6451,6 +6698,7 @@
 
 # newdoc id = test-s257
 # sent_id = test-s257
+# parallel_id = jagsd/test257
 # text = 席数はあまり多くないお店だが、食事の内容には満足出来る。
 1	席数	席数	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セキスウ,席数,席数,席数,セキスー,,,セキスウ,セキスウ,席数
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -6473,6 +6721,7 @@
 
 # newdoc id = test-s258
 # sent_id = test-s258
+# parallel_id = jagsd/test258
 # text = 整体やマッサージで良くならなかった人にもオススメします。
 1	整体	整体	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイタイ,整体,整体,整体,セータイ,,,セイタイ,セイタイ,整体
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -6493,6 +6742,7 @@
 
 # newdoc id = test-s259
 # sent_id = test-s259
+# parallel_id = jagsd/test259
 # text = こちらのホテルは多少の設備の古さは感じなくも無いものの、スタッフさんのサービスが普通のホテルのように行き届いています。
 1	こちら	此方	PRON	代名詞	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コチラ,此方,こちら,こちら,コチラ,,,コチラ,コチラ,此方
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6531,6 +6781,7 @@
 
 # newdoc id = test-s260
 # sent_id = test-s260
+# parallel_id = jagsd/test260
 # text = この低料金でこの設備を提供してくれるのはありがたいですね。
 1	この	此の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	低	低	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テイ,低,低,低,テー,,,テイ,テイリョウキン,低料金
@@ -6552,6 +6803,7 @@
 
 # newdoc id = test-s261
 # sent_id = test-s261
+# parallel_id = jagsd/test261
 # text = 仕事に疲れてフラフラでチェックインしても、フロントの方をはじめホテルのスタッフの方々が気持ちのいい対応をしてくれるので、泊まりに行きたくなります。
 1	仕事	仕事	NOUN	名詞-普通名詞-サ変可能	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シゴト,仕事,仕事,仕事,シゴト,,,シゴト,シゴト,仕事
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -6597,6 +6849,7 @@
 
 # newdoc id = test-s262
 # sent_id = test-s262
+# parallel_id = jagsd/test262
 # text = 値段相応といえばそれまでですが、風呂が狭いことだけが残念。
 1	値段	値段	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ネダン,値段,値段,値段,ネダン,,,ネダン,ネダンソウオウ,値段相応
 2	相応	相応	ADJ	名詞-普通名詞-サ変形状詞可能	_	4	ccomp	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ソウオウ,相応,相応,相応,ソーオー,,,ソウオウ,ネダンソウオウ,値段相応
@@ -6619,6 +6872,7 @@
 
 # newdoc id = test-s263
 # sent_id = test-s263
+# parallel_id = jagsd/test263
 # text = 従業員の方々もいつも暖かく送り出してくれるので、私が千葉で宿泊するホテルはここできまりです。
 1	従業	従業	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジュウギョウ,従業,従業,従業,ジューギョー,,,ジュウギョウ,ジュウギョウイン,従業員
 2	員	員	NOUN	接尾辞-名詞的-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イン,員,員,員,イン,,,イン,ジュウギョウイン,従業員
@@ -6650,6 +6904,7 @@
 
 # newdoc id = test-s264
 # sent_id = test-s264
+# parallel_id = jagsd/test264
 # text = ビジネスマンに対しての細かいところにまで気を配ったサービスがありがたく、ネットにキッチンにランドリーまで使えてこのお値段というのは安いと思います。
 1	ビジネスマン	ビジネスマン	NOUN	名詞-普通名詞-一般	_	14	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ビジネスマン,ビジネスマン,ビジネスマン,ビジネスマン,ビジネスマン,,,ビジネスマン,ビジネスマン,ビジネスマン
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニタイシテ,に対して
@@ -6691,6 +6946,7 @@
 
 # newdoc id = test-s265
 # sent_id = test-s265
+# parallel_id = jagsd/test265
 # text = 初めて宿泊したのですが、はじめてに感じない、そんなアットホームな雰囲気もあるホテルでした。
 1	初めて	初めて	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ハジメテ,初めて,初めて,初めて,ハジメテ,,,ハジメテ,ハジメテ,初めて
 2	宿泊	宿泊	VERB	名詞-普通名詞-サ変可能	_	21	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=シュクハク,宿泊,宿泊,宿泊,シュクハク,,,シュクハク,シュクハクスル,宿泊する
@@ -6719,6 +6975,7 @@
 
 # newdoc id = test-s266
 # sent_id = test-s266
+# parallel_id = jagsd/test266
 # text = ですがほかのブックオフの中型店では多くの店員を雇うと教育がされておらず、私語がうるさいと店員はそちらを向くと、なんと店員がおしゃべりしていた。
 1	です	です	CCONJ	助動詞-助動詞-デス	_	20	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|PrevUDLemma=だ|SpaceAfter=No|UnidicInfo=デス,です,です,です,デス,,,デス,デスガ,ですが
 2	が	が	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,デスガ,ですが
@@ -6770,6 +7027,7 @@
 
 # newdoc id = test-s267
 # sent_id = test-s267
+# parallel_id = jagsd/test267
 # text = もう少し早い時間に営業していると嬉しいですが、お店のスタンスはgoodです。
 1	もう	もう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=モウ,もう,もう,もう,モー,,,モウ,モウ,もう
 2	少し	少し	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=スコシ,少し,少し,少し,スコシ,,,スコシ,スコシ,少し
@@ -6796,6 +7054,7 @@
 
 # newdoc id = test-s269
 # sent_id = test-s269
+# parallel_id = jagsd/test269
 # text = あまり期待していなかったのに結構な額になったのでとてもうれしかったです。
 1	あまり	余り	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=アマリ,余り,あまり,あまり,アマリ,,,アマリ,アマリ,余り
 2	期待	期待	VERB	名詞-普通名詞-サ変可能	_	14	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=キタイ,期待,期待,期待,キタイ,,,キタイ,キタイスル,期待する
@@ -6822,6 +7081,7 @@
 
 # newdoc id = test-s270
 # sent_id = test-s270
+# parallel_id = jagsd/test270
 # text = 西友の中にあり、入りやすい雰囲気なので、初めての方にもオススメできます。
 1	西友	西友	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=セイユウ,西友,西友,西友,セーユー,,,セイユウ,セイユウ,西友
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6849,6 +7109,7 @@
 
 # newdoc id = test-s271
 # sent_id = test-s271
+# parallel_id = jagsd/test271
 # text = リーズナブルな価格、味は勿論のこと、若いマスター夫婦の温かい雰囲気についつい長居してしまいます。
 1	リーズナブル	リーズナブル	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=リーズナブル,リーズナブル,リーズナブル,リーズナブル,リーズナブル,,,リーズナブル,リーズナブル,リーズナブル
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -6877,6 +7138,7 @@
 
 # newdoc id = test-s272
 # sent_id = test-s272
+# parallel_id = jagsd/test272
 # text = 姫路の良く行く美容室でしたっ
 1	姫路	姫路	PROPN	名詞-固有名詞-地名-一般	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ヒメジ,ヒメジ,姫路,姫路,ヒメジ,,,ヒメジ,ヒメジ,姫路
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6890,6 +7152,7 @@
 
 # newdoc id = test-s273
 # sent_id = test-s273
+# parallel_id = jagsd/test273
 # text = 感じのいいスタッフさんなので安心して通えます。
 1	感じ	感じ	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カンジ,感じ,感じ,感じ,カンジ,,,カンジ,カンジ,感じ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -6908,6 +7171,7 @@
 
 # newdoc id = test-s274
 # sent_id = test-s274
+# parallel_id = jagsd/test274
 # text = 駐車場はあるものの立体駐車場で出入りに時間がかかり、6号と14号の交差点前で交通量が多くかつ駅前直結なため常に混雑しており、事実上地元の人以外のアクセスは辛いです。
 1	駐車	駐車	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チュウシャ,駐車,駐車,駐車,チューシャ,,,チュウシャ,チュウシャジョウ,駐車場
 2	場	場	NOUN	接尾辞-名詞的-一般	_	4	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョウ,場,場,場,ジョー,,,ジョウ,チュウシャジョウ,駐車場
@@ -6966,6 +7230,7 @@
 
 # newdoc id = test-s275
 # sent_id = test-s275
+# parallel_id = jagsd/test275
 # text = テキストもとても分かりやすいですし、旅行やホームステイに使える英語を勉強、練習できるので大変気に入っております。
 1	テキスト	テキスト	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テキスト,テキスト,テキスト,テキスト,テキスト,,,テキスト,テキスト,テキスト
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -6999,6 +7264,7 @@
 
 # newdoc id = test-s276
 # sent_id = test-s276
+# parallel_id = jagsd/test276
 # text = 小さいお店なので常連さん優先なのは仕方がないですね。
 1	小さい	小さい	ADJ	形容詞-一般-形容詞	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=チイサイ,小さい,小さい,小さい,チーサイ,,,チイサイ,チイサイ,小さい
 2	お	御	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オミセ,御店
@@ -7021,6 +7287,7 @@
 
 # newdoc id = test-s277
 # sent_id = test-s277
+# parallel_id = jagsd/test277
 # text = 振袖はかなり豊富で流行りのトレンド着物からベーシックなものまで色々とありました。
 1	振袖	振り袖	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フリソデ,振り袖,振袖,振袖,フリソデ,,,フリソデ,フリソデ,振り袖
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7045,6 +7312,7 @@
 
 # newdoc id = test-s278
 # sent_id = test-s278
+# parallel_id = jagsd/test278
 # text = つけ麺の王様は間違いなくここ。
 1	つけ麺	付け麺	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ツケメン,付け麺,つけ麺,つけ麺,ツケメン,,,ツケメン,ツケメン,付け麺
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7058,6 +7326,7 @@
 
 # newdoc id = test-s279
 # sent_id = test-s279
+# parallel_id = jagsd/test279
 # text = 袋や箱が、簡素で格好いいと思います。
 1	袋	袋	NOUN	名詞-普通名詞-助数詞可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フクロ,袋,袋,袋,フクロ,,,フクロ,フクロ,袋
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -7075,6 +7344,7 @@
 
 # newdoc id = test-s280
 # sent_id = test-s280
+# parallel_id = jagsd/test280
 # text = 味が少し濃いかなぁ。
 1	味	味	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アジ,味,味,味,アジ,,,アジ,アジ,味
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7086,6 +7356,7 @@
 
 # newdoc id = test-s281
 # sent_id = test-s281
+# parallel_id = jagsd/test281
 # text = 院長と話をしたところ、腰痛治療も得意なようです。
 1	院長	院長	NOUN	名詞-普通名詞-一般	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=インチョウ,院長,院長,院長,インチョー,,,インチョウ,インチョウ,院長
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -7106,6 +7377,7 @@
 
 # newdoc id = test-s282
 # sent_id = test-s282
+# parallel_id = jagsd/test282
 # text = お客さんはガヤガヤしたところがイヤな方はいいかもしれません。
 1	お	御	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オ,御,お,お,オ,,,オ,オキャクサン,御客さん
 2	客	客	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キャク,客,客,客,キャク,,,キャク,オキャクサン,御客さん
@@ -7130,6 +7402,7 @@
 
 # newdoc id = test-s284
 # sent_id = test-s284
+# parallel_id = jagsd/test284
 # text = 石川悦男元党首は,宗教法人の総本山に異動となりました。
 1	石川	石川	PROPN	名詞-固有名詞-人名-姓	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=イシカワ,イシカワ,石川,石川,イシカワ,,,イシカワ,イシカワエツオモトトウシュ,石川悦男元党首
 2	悦男	悦男	PROPN	名詞-固有名詞-人名-名	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=エツオ,エツオ,悦男,悦男,エツオ,,,エツオ,イシカワエツオモトトウシュ,石川悦男元党首
@@ -7152,6 +7425,7 @@
 
 # newdoc id = test-s285
 # sent_id = test-s285
+# parallel_id = jagsd/test285
 # text = おいしいと聞いてただけに姉には申し訳なくてホントに最悪です
 1	おいしい	美味しい	ADJ	形容詞-一般-形容詞	_	3	ccomp	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=オイシイ,美味しい,おいしい,おいしい,オイシー,,,オイシイ,オイシイ,美味しい
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -7173,6 +7447,7 @@
 
 # newdoc id = test-s286
 # sent_id = test-s286
+# parallel_id = jagsd/test286
 # text = セレファイスの主神。
 1	セレファイス	セレファイス	PROPN	名詞-固有名詞-地名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=セレファイス,セレファイス,セレファイス,セレファイス,セレファイス,,,セレファイス,セレファイス,セレファイス
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7181,6 +7456,7 @@
 
 # newdoc id = test-s287
 # sent_id = test-s287
+# parallel_id = jagsd/test287
 # text = 一郎の妻。
 1	一郎	一郎	PROPN	名詞-固有名詞-人名-名	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-名|SpaceAfter=No|UnidicInfo=イチロウ,イチロウ,一郎,一郎,イチロー,,,イチロウ,イチロウ,一郎
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7189,6 +7465,7 @@
 
 # newdoc id = test-s288
 # sent_id = test-s288
+# parallel_id = jagsd/test288
 # text = なお、冬期には山腹にスポットライトで雪だるまが描かれる。
 1	なお	猶	CCONJ	接続詞	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7208,6 +7485,7 @@
 
 # newdoc id = test-s289
 # sent_id = test-s289
+# parallel_id = jagsd/test289
 # text = この建物は、初めオフィスとして用いられたが、1909年からは市庁舎として利用された。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	建物	建物	NOUN	名詞-普通名詞-一般	_	24	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タテモノ,建物,建物,建物,タテモノ,,,タテモノ,タテモノ,建物
@@ -7240,6 +7518,7 @@
 
 # newdoc id = test-s290
 # sent_id = test-s290
+# parallel_id = jagsd/test290
 # text = 誕生日10月16日。
 1	誕生	誕生	NOUN	名詞-普通名詞-サ変可能	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タンジョウ,誕生,誕生,誕生,タンジョー,,,タンジョウ,タンジョウビ,誕生日
 2	日	日	NOUN	名詞-普通名詞-副詞可能	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ビ,,,ヒ,タンジョウビ,誕生日
@@ -7251,6 +7530,7 @@
 
 # newdoc id = test-s291
 # sent_id = test-s291
+# parallel_id = jagsd/test291
 # text = また、先生方をサポートする人材の育成、教員養成のあり方を詰めていく必要がある。
 1	また	又	CCONJ	接続詞	_	23	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7279,6 +7559,7 @@
 
 # newdoc id = test-s292
 # sent_id = test-s292
+# parallel_id = jagsd/test292
 # text = 事件が朝刊各版の締め切り間際に立て続けに起こったため、各新聞は配達先によって記事内容が一部異なっている。
 1	事件	事件	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジケン,事件,事件,事件,ジケン,,,ジケン,ジケン,事件
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -7313,6 +7594,7 @@
 
 # newdoc id = test-s293
 # sent_id = test-s293
+# parallel_id = jagsd/test293
 # text = 番外編に登場。
 1	番外	番外	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バンガイ,番外,番外,番外,バンガイ,,,バンガイ,バンガイヘン,番外編
 2	編	編	NOUN	名詞-普通名詞-助数詞可能	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヘン,編,編,編,ヘン,,,ヘン,バンガイヘン,番外編
@@ -7322,6 +7604,7 @@
 
 # newdoc id = test-s295
 # sent_id = test-s295
+# parallel_id = jagsd/test295
 # text = 最高なお店で毎回感動しています。
 1	最高	最高	ADJ	名詞-普通名詞-形状詞可能	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=サイコウ,最高,最高,最高,サイコー,,,サイコウ,サイコウ,最高
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -7338,6 +7621,7 @@
 
 # newdoc id = test-s296
 # sent_id = test-s296
+# parallel_id = jagsd/test296
 # text = 自分でも趣味で料理をするもので一層感心することが多いのです。
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -7361,6 +7645,7 @@
 
 # newdoc id = test-s297
 # sent_id = test-s297
+# parallel_id = jagsd/test297
 # text = 1967年『シラノ・ド・ベルジュラック』で初舞台。
 1	1967	1967	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九六七,1967,1967,イチキューロクシチ,,,イチキュウロクシチ,イチキュウロクシチネン,1967年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	12	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチキュウロクシチネン,1967年
@@ -7378,6 +7663,7 @@
 
 # newdoc id = test-s298
 # sent_id = test-s298
+# parallel_id = jagsd/test298
 # text = 人間の体は何百万年前からそのことを知っていて、体の中にウイルス等の外敵が侵入してくると、彼らと戦うために脳から全身の細胞に指令を出して熱を出しているそうです。
 1	人間	人間	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニンゲン,人間,人間,人間,ニンゲン,,,ニンゲン,ニンゲン,人間
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7438,6 +7724,7 @@
 
 # newdoc id = test-s299
 # sent_id = test-s299
+# parallel_id = jagsd/test299
 # text = 東京にあるハイパーコンサルティング・ジャパンさんでは、パニック障害解消プログラムを組んでカウンセリングを実施しています。
 1	東京	東京	PROPN	名詞-固有名詞-地名-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=トウキョウ,トウキョウ,東京,東京,トーキョー,,,トウキョウ,トウキョウ,東京
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7468,6 +7755,7 @@
 
 # newdoc id = test-s300
 # sent_id = test-s300
+# parallel_id = jagsd/test300
 # text = 公称身長156cm。
 1	公称	公称	NOUN	名詞-普通名詞-サ変可能	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウショウ,公称,公称,公称,コーショー,,,コウショウ,コウショウシンチョウ,公称身長
 2	身長	身長	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンチョウ,身長,身長,身長,シンチョー,,,シンチョウ,コウショウシンチョウ,公称身長
@@ -7477,6 +7765,7 @@
 
 # newdoc id = test-s301
 # sent_id = test-s301
+# parallel_id = jagsd/test301
 # text = また,木村党首が“参院選の目玉政策”として掲げたのが,“参議院の廃止”。
 1	また	又	CCONJ	接続詞	_	25	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -7508,6 +7797,7 @@
 
 # newdoc id = test-s302
 # sent_id = test-s302
+# parallel_id = jagsd/test302
 # text = ボルバキアという共生細菌がいないと正常な成長や繁殖が困難であることが研究で明らかにされた。
 1	ボルバキア	ボルバキア	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ボルバキア,ボルバキア,ボルバキア,ボルバキア,ボルバキア,,,ボルバキア,ボルバキア,ボルバキア
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,トイウ,という
@@ -7540,6 +7830,7 @@
 
 # newdoc id = test-s303
 # sent_id = test-s303
+# parallel_id = jagsd/test303
 # text = 2007年9月5日発売。
 1	2007	2007	NUM	名詞-数詞	_	7	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ七,2007,2007,ニゼロゼロシチ,,,ニゼロゼロシチ,ニゼロゼロシチネン,2007年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	7	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロシチネン,2007年
@@ -7552,6 +7843,7 @@
 
 # newdoc id = test-s304
 # sent_id = test-s304
+# parallel_id = jagsd/test304
 # text = 文書をどのようにファイルするか。
 1	文書	文書	NOUN	名詞-普通名詞-一般	_	6	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ブンショ,文書,文書,文書,ブンショ,,,ブンショ,ブンショ,文書
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -7565,6 +7857,7 @@
 
 # newdoc id = test-s305
 # sent_id = test-s305
+# parallel_id = jagsd/test305
 # text = そのほかアダナ近郊のシルケリ・ホユックでは彼の名が刻まれた摩崖碑文が発見されているが、こうした屋外のヒッタイト碑文としては最古の例とされる。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	ほか	他	NOUN	名詞-普通名詞-副詞可能	_	21	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホカ,他,ほか,ほか,ホカ,,,ホカ,ホカ,他
@@ -7614,6 +7907,7 @@
 
 # newdoc id = test-s306
 # sent_id = test-s306
+# parallel_id = jagsd/test306
 # text = 次のカットまでのスタイリングも「パパッ」と出来てしまいます。
 1	次	次	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ツギ,次,次,次,ツギ,,,ツギ,ツギ,次
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7634,6 +7928,7 @@
 
 # newdoc id = test-s307
 # sent_id = test-s307
+# parallel_id = jagsd/test307
 # text = 独立して活動する弦楽四重奏団としては日本で最も実績を重ねている団体の一つ。
 1	独立	独立	VERB	名詞-普通名詞-サ変形状詞可能	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=ドクリツ,独立,独立,独立,ドクリツ,,,ドクリツ,ドクリツスル,独立する
 2	し	為る	AUX	動詞-非自立可能-サ行変格	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,ドクリツスル,独立する
@@ -7665,6 +7960,7 @@
 
 # newdoc id = test-s308
 # sent_id = test-s308
+# parallel_id = jagsd/test308
 # text = そののち、連隊はレンドリースにより供与されたボストンに装備を変更した。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	のち	後	NOUN	名詞-普通名詞-副詞可能	_	17	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ノチ,後,のち,のち,ノチ,,,ノチ,ノチ,後
@@ -7689,12 +7985,14 @@
 
 # newdoc id = test-s309
 # sent_id = test-s309
+# parallel_id = jagsd/test309
 # text = Ciao!
 1	Ciao	Ciao	NOUN	名詞-普通名詞-一般	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チャオ,チャオ,Ciao,Ciao,チャオ,,,チャオ,チャオ,Ciao
 2	!	!	PUNCT	補助記号-句点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-句点|UnidicInfo=,！,!,!,,,,,,！
 
 # newdoc id = test-s310
 # sent_id = test-s310
+# parallel_id = jagsd/test310
 # text = ジェリーとリズは恋仲になるが、アンリはリズと結婚しようとしていた。
 1	ジェリー	ジェリー	PROPN	名詞-固有名詞-人名-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ジェリー,ジェリー,ジェリー,ジェリー,ジェリー,,,ジェリー,ジェリー,ジェリー
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -7720,6 +8018,7 @@
 
 # newdoc id = test-s311
 # sent_id = test-s311
+# parallel_id = jagsd/test311
 # text = また、奴隷貿易の対象ではなく宗教上のライバルであった北アフリカのイスラム諸国は、19世紀には宗主国オスマン帝国の影響力が衰え、自立した群小政権もヨーロッパ勢力の経済的・軍事的な発展に対してほとんど為す術がないほど弱体化していた。
 1	また	又	CCONJ	接続詞	_	64	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -7793,6 +8092,7 @@
 
 # newdoc id = test-s312
 # sent_id = test-s312
+# parallel_id = jagsd/test312
 # text = 実際に万全ではなかったり手を抜いている時以外の、真弥が本気で戦った戦闘では必ずその相手に圧勝している。
 1	実際	実際	NOUN	名詞-普通名詞-副詞可能	_	30	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジッサイ,実際,実際,実際,ジッサイ,,,ジッサイ,ジッサイ,実際
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7831,6 +8131,7 @@
 
 # newdoc id = test-s313
 # sent_id = test-s313
+# parallel_id = jagsd/test313
 # text = ただし完全に外海から隔てられたものはほとんどなく、ごく狭い海峡により外海とつながっているものが多い。
 1	ただし	但し	CCONJ	接続詞	_	26	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	完全	完全	ADJ	形状詞-一般	_	6	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=カンゼン,完全,完全,完全,カンゼン,,,カンゼン,カンゼン,完全
@@ -7862,6 +8163,7 @@
 
 # newdoc id = test-s314
 # sent_id = test-s314
+# parallel_id = jagsd/test314
 # text = 以下は「表向き」を好むと答えた人間の割合である。
 1	以下	以下	NOUN	名詞-普通名詞-一般	_	13	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イカ,以下,以下,以下,イカ,,,イカ,イカ,以下
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -7882,6 +8184,7 @@
 
 # newdoc id = test-s315
 # sent_id = test-s315
+# parallel_id = jagsd/test315
 # text = バトルに敗北するとどうなるかは作品ごとに決められている。
 1	バトル	バトル	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バトル,バトル,バトル,バトル,バトル,,,バトル,バトル,バトル
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -7903,6 +8206,7 @@
 
 # newdoc id = test-s316
 # sent_id = test-s316
+# parallel_id = jagsd/test316
 # text = 通常この協議は1〜4年かかるとされている。
 1	通常	通常	ADV	名詞-普通名詞-副詞可能	_	11	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ツウジョウ,通常,通常,通常,ツージョー,,,ツウジョウ,ツウジョウ,通常
 2	この	此の	DET	連体詞	_	3	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
@@ -7922,6 +8226,7 @@
 
 # newdoc id = test-s317
 # sent_id = test-s317
+# parallel_id = jagsd/test317
 # text = ひびの入ったパネル。
 1	ひび	皹	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒビ,皹,ひび,ひび,ヒビ,,,ヒビ,ヒビ,皹
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -7932,6 +8237,7 @@
 
 # newdoc id = test-s318
 # sent_id = test-s318
+# parallel_id = jagsd/test318
 # text = 昨日も仲間8人で楽しくおいしくいただきました。
 1	昨日	昨日	ADV	名詞-普通名詞-副詞可能	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=キノウ,昨日,昨日,昨日,キノー,,,キノウ,キノウ,昨日
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -7948,6 +8254,7 @@
 
 # newdoc id = test-s319
 # sent_id = test-s319
+# parallel_id = jagsd/test319
 # text = デビュー当時からテレビにはほとんど出演しないが、CS放送には出演したことがある。
 1	デビュー	デビュー	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=デビュー,デビュー,デビュー,デビュー,デビュー,,,デビュー,デビュートウジ,デビュー当時
 2	当時	当時	NOUN	名詞-普通名詞-副詞可能	_	8	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウジ,当時,当時,当時,トージ,,,トウジ,デビュートウジ,デビュー当時
@@ -7975,6 +8282,7 @@
 
 # newdoc id = test-s320
 # sent_id = test-s320
+# parallel_id = jagsd/test320
 # text = 祖国を侵略者ベトナムから解放するその一点で闘う少年兵,少女兵の笑顔にまさるものはない。
 1	祖国	祖国	NOUN	名詞-普通名詞-一般	_	7	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ソコク,祖国,祖国,祖国,ソコク,,,ソコク,ソコク,祖国
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8005,6 +8313,7 @@
 
 # newdoc id = test-s321
 # sent_id = test-s321
+# parallel_id = jagsd/test321
 # text = しかし取材していても,特定のイデオロギーや党派組織の影響を感じません。
 1	しかし	然し	CCONJ	接続詞	_	18	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	取材	取材	VERB	名詞-普通名詞-サ変可能	_	18	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=シュザイ,取材,取材,取材,シュザイ,,,シュザイ,シュザイスル,取材する
@@ -8030,6 +8339,7 @@
 
 # newdoc id = test-s322
 # sent_id = test-s322
+# parallel_id = jagsd/test322
 # text = エレクトロウェッティングは既存の液晶ディスプレイ生産ラインに変更を加えれば製造できるという。
 1	エレクトロウェッティング	エレクトロウェッティング	NOUN	名詞-普通名詞-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エレクトロウェッティング,エレクトロウェッティング,エレクトロウェッティング,エレクトロウェッティング,エレクトローェッティング,,,エレクトロウェッティング,エレクトロウェッティング,エレクトロウェッティング
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8052,6 +8362,7 @@
 
 # newdoc id = test-s323
 # sent_id = test-s323
+# parallel_id = jagsd/test323
 # text = しかし、ルートによっては悠弥と結婚することになり、彼女のルートでは全ヒロイン中、ハッピーエンドを迎える。
 1	しかし	然し	CCONJ	接続詞	_	28	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -8085,6 +8396,7 @@
 
 # newdoc id = test-s324
 # sent_id = test-s324
+# parallel_id = jagsd/test324
 # text = 今後,この様な問題の発生を防止する為,国家は厳しい規制を考える必要がある。
 1	今後	今後	ADV	名詞-普通名詞-副詞可能	_	10	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=コンゴ,今後,今後,今後,コンゴ,,,コンゴ,コンゴ,今後
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -8112,6 +8424,7 @@
 
 # newdoc id = test-s325
 # sent_id = test-s325
+# parallel_id = jagsd/test325
 # text = 会社がお世話をしてくれなかったので自分で探したのですが、価格的にも割と負担のすくないこちらのマンスリーマンションを借りることになりました。
 1	会社	会社	NOUN	名詞-普通名詞-一般	_	6	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイシャ,会社,会社,会社,カイシャ,,,カイシャ,カイシャ,会社
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -8156,6 +8469,7 @@
 
 # newdoc id = test-s326
 # sent_id = test-s326
+# parallel_id = jagsd/test326
 # text = 野田佳彦首相は12月に中国を訪問する方向で最終調整に入った。
 1	野田	野田	PROPN	名詞-固有名詞-人名-姓	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ノダ,ノダ,野田,野田,ノダ,,,ノダ,ノダヨシヒコシュショウ,野田佳彦首相
 2	佳彦	佳彦	PROPN	名詞-固有名詞-人名-名	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ヨシヒコ,ヨシヒコ,佳彦,佳彦,ヨシヒコ,,,ヨシヒコ,ノダヨシヒコシュショウ,野田佳彦首相
@@ -8179,6 +8493,7 @@
 
 # newdoc id = test-s327
 # sent_id = test-s327
+# parallel_id = jagsd/test327
 # text = 第1期終了後、素顔を晒して謎のレスラー「キャプテン・モロー」として過ごし、チャンピオンにまでなっていた。
 1	第	第	NOUN	接頭辞	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ダイ,第,第,第,ダイ,,,ダイ,ダイイッキシュウリョウゴ,第1期終了後
 2	1	1	NUM	名詞-数詞	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イチ,一,1,1,イッ,,,イチ,ダイイッキシュウリョウゴ,第1期終了後
@@ -8214,6 +8529,7 @@
 
 # newdoc id = test-s328
 # sent_id = test-s328
+# parallel_id = jagsd/test328
 # text = 管轄する修道院がそもそも日本に存在しなかったのに、日本に正教会を伝えた亜使徒聖ニコライが日本伝道初期に掌院に昇叙されたことはその好例である。
 1	管轄	管轄	VERB	名詞-普通名詞-サ変可能	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=カンカツ,管轄,管轄,管轄,カンカツ,,,カンカツ,カンカツスル,管轄する
 2	する	為る	AUX	動詞-非自立可能-サ行変格	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,する,する,スル,,,スル,カンカツスル,管轄する
@@ -8262,6 +8578,7 @@
 
 # newdoc id = test-s329
 # sent_id = test-s329
+# parallel_id = jagsd/test329
 # text = ガッローネは出資をあまり大規模に行なわず、マロッタと監督の手腕にすべてをゆだねている。
 1	ガッローネ	ガッローネ	PROPN	名詞-固有名詞-人名-一般	_	20	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ガッローネ,ガッローネ,ガッローネ,ガッローネ,ガッローネ,,,ガッローネ,ガッローネ,ガッローネ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8289,6 +8606,7 @@
 
 # newdoc id = test-s330
 # sent_id = test-s330
+# parallel_id = jagsd/test330
 # text = 上記の理由で当時はさほど売り上げにつながらなかったが、1990年代後半以降、業務用・家庭用ゲームでこれと似た体感ゲームが登場してきている。
 1	上記	上記	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョウキ,上記,上記,上記,ジョーキ,,,ジョウキ,ジョウキ,上記
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8334,6 +8652,7 @@
 
 # newdoc id = test-s331
 # sent_id = test-s331
+# parallel_id = jagsd/test331
 # text = その姿は見る者によって異なり、洋子には幼い頃の自分に見えた。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	姿	姿	NOUN	名詞-普通名詞-一般	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スガタ,姿,姿,姿,スガタ,,,スガタ,スガタ,姿
@@ -8359,6 +8678,7 @@
 
 # newdoc id = test-s332
 # sent_id = test-s332
+# parallel_id = jagsd/test332
 # text = 事件の原因が新健康協会の教義にあったことは判決が認定しているようですし,裁判員の言葉の通り両親が子どもに対して“一生懸命愛情を持って接していた”のであれば,その愛情を間違った方向に走らせてしまった新健康協会は,なおのこと危険な団体であるということになります。
 1	事件	事件	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジケン,事件,事件,事件,ジケン,,,ジケン,ジケン,事件
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8448,6 +8768,7 @@
 
 # newdoc id = test-s333
 # sent_id = test-s333
+# parallel_id = jagsd/test333
 # text = クロアチアは、アドリア海のイタリアとの中間線よりクロアチア側に、排他的経済水域を設定することを計画している。
 1	クロアチア	クロアチア	PROPN	名詞-固有名詞-地名-国	_	26	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=クロアチア,クロアチア,クロアチア,クロアチア,クロアチア,,,クロアチア,クロアチア,クロアチア
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -8482,6 +8803,7 @@
 
 # newdoc id = test-s334
 # sent_id = test-s334
+# parallel_id = jagsd/test334
 # text = 復興基本計画は、昭和20年から21年にかけて、市の関係部局や学識経験者、市民代表により復興計画に関する委員会で決定され、狭い市域に多くの人口を収容するために商工業・中小企業を発展させることを基本方針にし、区画整理の実施を幹線道路の整備による経済活動の円滑化とこれまで不足していた公園緑地の確保による都市美化、従来の不規則な街区整理を目的に、着実に着工する。
 1	復興	復興	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フッコウ,復興,復興,復興,フッコー,,,フッコウ,フッコウキホンケイカク,復興基本計画
 2	基本	基本	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キホン,基本,基本,基本,キホン,,,キホン,フッコウキホンケイカク,復興基本計画
@@ -8601,6 +8923,7 @@
 
 # newdoc id = test-s335
 # sent_id = test-s335
+# parallel_id = jagsd/test335
 # text = 土曜日の夜、仕事帰りに一人でふらりと立ち寄りました。
 1	土曜	土曜	NOUN	名詞-普通名詞-副詞可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドヨウ,土曜,土曜,土曜,ドヨー,,,ドヨウ,ドヨウビ,土曜日
 2	日	日	NOUN	名詞-普通名詞-副詞可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒ,日,日,日,ビ,,,ヒ,ドヨウビ,土曜日
@@ -8620,6 +8943,7 @@
 
 # newdoc id = test-s336
 # sent_id = test-s336
+# parallel_id = jagsd/test336
 # text = 最高裁の御威光によって,文科省の判断が“違法”認定。
 1	最高	最高	NOUN	名詞-普通名詞-形状詞可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サイコウ,最高,最高,最高,サイコー,,,サイコウ,サイコウサイ,最高裁
 2	裁	裁	NOUN	接尾辞-名詞的-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サイ,裁,裁,裁,サイ,,,サイ,サイコウサイ,最高裁
@@ -8643,6 +8967,7 @@
 
 # newdoc id = test-s337
 # sent_id = test-s337
+# parallel_id = jagsd/test337
 # text = 2009年地方競馬通算900勝達成。
 1	2009	2009	NUM	名詞-数詞	_	8	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ九,2009,2009,ニゼロゼロキュー,,,ニゼロゼロキュウ,ニゼロゼロキュウネンチホウケイバツウサン,2009年地方競馬通算
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	8	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロキュウネンチホウケイバツウサン,2009年地方競馬通算
@@ -8656,6 +8981,7 @@
 
 # newdoc id = test-s338
 # sent_id = test-s338
+# parallel_id = jagsd/test338
 # text = エジプト情勢緊迫化の影響が国際商品市況へ波及し、世界景気に悪影響を及ぼす可能性が警戒された。
 1	エジプト	エジプト	PROPN	名詞-固有名詞-地名-国	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エジプト,エジプト,エジプト,エジプト,エジプト,,,エジプト,エジプトジョウセイキンパクカ,エジプト情勢緊迫化
 2	情勢	情勢	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョウセイ,情勢,情勢,情勢,ジョーセー,,,ジョウセイ,エジプトジョウセイキンパクカ,エジプト情勢緊迫化
@@ -8689,6 +9015,7 @@
 
 # newdoc id = test-s339
 # sent_id = test-s339
+# parallel_id = jagsd/test339
 # text = 漫画『DEATH NOTE』のパロディ。
 1	漫画	漫画	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マンガ,漫画,漫画,漫画,マンガ,,,マンガ,マンガ,漫画
 2	『	『	PUNCT	補助記号-括弧開	_	4	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,『,『,『,,,,,,『
@@ -8701,6 +9028,7 @@
 
 # newdoc id = test-s340
 # sent_id = test-s340
+# parallel_id = jagsd/test340
 # text = すごろくを基本にしたゲームで、ドックロンが揺らす邪魔で落ちないようにしながらゴールまで進んでいく。
 1	すごろく	双六	NOUN	名詞-普通名詞-一般	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スゴロク,双六,すごろく,すごろく,スゴロク,,,スゴロク,スゴロク,双六
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -8731,6 +9059,7 @@
 
 # newdoc id = test-s341
 # sent_id = test-s341
+# parallel_id = jagsd/test341
 # text = 歴史上では、中国・後漢末期に発生した、党錮の禁で弾圧された集団の称として使われた。
 1	歴史	歴史	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=レキシ,歴史,歴史,歴史,レキシ,,,レキシ,レキシジョウ,歴史上
 2	上	上	NOUN	接尾辞-名詞的-副詞可能	_	29	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョウ,上,上,上,ジョー,,,ジョウ,レキシジョウ,歴史上
@@ -8767,6 +9096,7 @@
 
 # newdoc id = test-s342
 # sent_id = test-s342
+# parallel_id = jagsd/test342
 # text = キャラクターの心臓部とも言える、動作を制御するファイル。
 1	キャラクター	キャラクター	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キャラクター,キャラクター,キャラクター,キャラクター,キャラクター,,,キャラクター,キャラクター,キャラクター
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -8785,6 +9115,7 @@
 
 # newdoc id = test-s343
 # sent_id = test-s343
+# parallel_id = jagsd/test343
 # text = 同じビルに調剤薬局もあるので会計後にそのまま向かうのが基本ルートです。
 1	同じ	同じ	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=オナジ,同じ,同じ,同じ,オナジ,,,オナジ,オナジ,同じ
 2	ビル	ビル	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ビル,ビル,ビル,ビル,ビル,,,ビル,ビル,蛭
@@ -8810,6 +9141,7 @@
 
 # newdoc id = test-s344
 # sent_id = test-s344
+# parallel_id = jagsd/test344
 # text = なお同馬はこのレースに於いて発走枠入りを再三嫌がり、出走を遅らせたため一定期間出走停止とゲート再試験が科せられている。
 1	なお	猶	CCONJ	接続詞	_	30	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	同馬	同馬	NOUN	名詞-普通名詞-一般	_	30	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウバ,同馬,同馬,同馬,ドーバ,,,ドウバ,ドウバ,同馬
@@ -8848,6 +9180,7 @@
 
 # newdoc id = test-s345
 # sent_id = test-s345
+# parallel_id = jagsd/test345
 # text = また,この養護教諭は,砂糖玉をレメディーに変換するという装置を保健室に持ち込んでいた。
 1	また	又	CCONJ	接続詞	_	22	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -8878,6 +9211,7 @@
 
 # newdoc id = test-s346
 # sent_id = test-s346
+# parallel_id = jagsd/test346
 # text = 線形作用素が有界であることと、連続であることは必要十分である。
 1	線形	線形	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センケイ,線形,線形,線形,センケー,,,センケイ,センケイサヨウソ,線形作用素
 2	作用	作用	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サヨウ,作用,作用,作用,サヨー,,,サヨウ,センケイサヨウソ,線形作用素
@@ -8902,6 +9236,7 @@
 
 # newdoc id = test-s347
 # sent_id = test-s347
+# parallel_id = jagsd/test347
 # text = 一方NASAのエイムズ研究センターが開発したナノセイルDは2008年8月にファルコン1ロケットによって打ち上げられるも打上げに失敗。
 1	一方	一方	CCONJ	接続詞	_	31	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	NASA	NASA	PROPN	名詞-固有名詞-一般	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ナサ,ＮＡＳＡ,NASA,NASA,ナサ,,,ナサ,ナサ,NASA
@@ -8938,6 +9273,7 @@
 
 # newdoc id = test-s348
 # sent_id = test-s348
+# parallel_id = jagsd/test348
 # text = だんなさまにもこの気持ち良さを体感してもらって、スクールに通うOKをもらいます!
 1	だんな	旦那	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダンナ,旦那,だんな,だんな,ダンナ,,,ダンナ,ダンナサマ,旦那様
 2	さま	様	NOUN	接尾辞-名詞的-一般	_	10	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|PrevUDLemma=よう|SpaceAfter=No|UnidicInfo=サマ,様,さま,さま,サマ,,,サマ,ダンナサマ,旦那様
@@ -8965,6 +9301,7 @@
 
 # newdoc id = test-s349
 # sent_id = test-s349
+# parallel_id = jagsd/test349
 # text = 冬季に利用。
 1	冬季	冬季	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウキ,冬季,冬季,冬季,トーキ,,,トウキ,トウキ,冬季
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -8973,6 +9310,7 @@
 
 # newdoc id = test-s350
 # sent_id = test-s350
+# parallel_id = jagsd/test350
 # text = このため先に派遣されていた2個偵察機隊に加え、新たに偵察機隊を追加派遣することとなり、事変勃発から1ヵ月後に追加編制されたのが二三空である。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	ため	為	NOUN	名詞-普通名詞-副詞可能	_	26	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タメ,為,ため,ため,タメ,,,タメ,タメ,為
@@ -9027,6 +9365,7 @@
 
 # newdoc id = test-s351
 # sent_id = test-s351
+# parallel_id = jagsd/test351
 # text = なお、常陸国から佐竹氏の秋田転封に随行した菊池氏が数流見える。
 1	なお	猶	CCONJ	接続詞	_	20	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ナオ,猶,なお,なお,ナオ,,,ナオ,ナオ,猶
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9052,6 +9391,7 @@
 
 # newdoc id = test-s352
 # sent_id = test-s352
+# parallel_id = jagsd/test352
 # text = かけがえのない家族を突然失う悲しみを知るだけに、できることをしたいと考えている。
 1	かけがえ	掛け替え	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カケガエ,掛け替え,かけがえ,かけがえ,カケガエ,,,カケガエ,カケガエ,掛け替え
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9079,6 +9419,7 @@
 
 # newdoc id = test-s353
 # sent_id = test-s353
+# parallel_id = jagsd/test353
 # text = そして、テレビ朝日同様縁取りは行われていない。
 1	そして	そして	CCONJ	接続詞	_	8	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -9096,6 +9437,7 @@
 
 # newdoc id = test-s354
 # sent_id = test-s354
+# parallel_id = jagsd/test354
 # text = 上に引用した部分以外も同様です。
 1	上	上	NOUN	名詞-普通名詞-副詞可能	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ウエ,上,上,上,ウエ,,,ウエ,ウエ,上
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -9111,6 +9453,7 @@
 
 # newdoc id = test-s355
 # sent_id = test-s355
+# parallel_id = jagsd/test355
 # text = 欧州不正対策局の付属機関である欧州技術・科学センターは、2002年の時点で最大で200万枚の偽造硬貨が出回っていると推測している。
 1	欧州	欧州	PROPN	名詞-固有名詞-地名-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オウシュウ,オウシュウ,欧州,欧州,オーシュー,,,オウシュウ,オウシュウフセイタイサクキョク,欧州不正対策局
 2	不正	不正	NOUN	名詞-普通名詞-形状詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フセイ,不正,不正,不正,フセー,,,フセイ,オウシュウフセイタイサクキョク,欧州不正対策局
@@ -9154,6 +9497,7 @@
 
 # newdoc id = test-s356
 # sent_id = test-s356
+# parallel_id = jagsd/test356
 # text = 新ルールを聞いて、各々に想いを語った。
 1	新	新	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シン,新,新,新,シン,,,シン,シンルール,新ルール
 2	ルール	ルール	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ルール,ルール,ルール,ルール,ルール,,,ルール,シンルール,新ルール
@@ -9171,6 +9515,7 @@
 
 # newdoc id = test-s357
 # sent_id = test-s357
+# parallel_id = jagsd/test357
 # text = マイカーの輸送力は公共交通機関に比べて遥かに劣るため、比較的小規模な都市でも混雑問題が深刻化する。
 1	マイ	マイ	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マイ,マイ,マイ,マイ,マイ,,,マイ,マイカー,マイカー
 2	カー	カー	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カー,カー,カー,カー,カー,,,カー,マイカー,マイカー
@@ -9207,6 +9552,7 @@
 
 # newdoc id = test-s358
 # sent_id = test-s358
+# parallel_id = jagsd/test358
 # text = 私は高校生の頃に臨床心理士になりたいと思い、心理学が学べる大学を片っ端から調べ、行けるだけオープンキャンパスに行きました。
 1	私	私	PRON	代名詞	_	32	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9246,6 +9592,7 @@
 
 # newdoc id = test-s359
 # sent_id = test-s359
+# parallel_id = jagsd/test359
 # text = ストーリー重視の作品を中心に掲載しているため過激な性的描写はほとんど見あたらない。
 1	ストーリー	ストーリー	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ストーリー,ストーリー,ストーリー,ストーリー,ストーリー,,,ストーリー,ストーリージュウシ,ストーリー重視
 2	重視	重視	NOUN	名詞-普通名詞-サ変可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジュウシ,重視,重視,重視,ジューシ,,,ジュウシ,ストーリージュウシ,ストーリー重視
@@ -9271,6 +9618,7 @@
 
 # newdoc id = test-s360
 # sent_id = test-s360
+# parallel_id = jagsd/test360
 # text = 直純より一年早く務め始めている。
 1	直純	直純	PROPN	名詞-固有名詞-人名-名	_	5	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-名|SpaceAfter=No|UnidicInfo=ナオズミ,ナオズミ,直純,直純,ナオズミ,,,ナオズミ,ナオズミ,直純
 2	より	より	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヨリ,より,より,より,ヨリ,,,ヨリ,ヨリ,より
@@ -9285,6 +9633,7 @@
 
 # newdoc id = test-s361
 # sent_id = test-s361
+# parallel_id = jagsd/test361
 # text = 子供の頃は『仮面ライダーBLACK』や『機動刑事ジバン』が好きだった。
 1	子供	子供	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コドモ,子供,子供,子供,コドモ,,,コドモ,コドモ,子供
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9309,6 +9658,7 @@
 
 # newdoc id = test-s362
 # sent_id = test-s362
+# parallel_id = jagsd/test362
 # text = 注文をすぐにとりにこない。
 1	注文	注文	NOUN	名詞-普通名詞-サ変可能	_	5	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チュウモン,注文,注文,注文,チューモン,,,チュウモン,チュウモン,注文
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -9322,6 +9672,7 @@
 
 # newdoc id = test-s363
 # sent_id = test-s363
+# parallel_id = jagsd/test363
 # text = 北沢氏は防衛省と自衛隊の内部の検討だとした上で、派遣の根拠となる法令に関して防衛省設置法を念頭に「派遣が可能か検討している」と述べた。
 1	北沢	北沢	PROPN	名詞-固有名詞-人名-姓	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=キタザワ,キタザワ,北沢,北沢,キタザワ,,,キタザワ,キタザワシ,北沢氏
 2	氏	氏	NOUN	接尾辞-名詞的-一般	_	47	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=シ,氏,氏,氏,シ,,,シ,キタザワシ,北沢氏
@@ -9375,6 +9726,7 @@
 
 # newdoc id = test-s364
 # sent_id = test-s364
+# parallel_id = jagsd/test364
 # text = コウスケたち三年二組の担任。
 1	コウスケ	コウスケ	PROPN	名詞-固有名詞-人名-名	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウスケ,コウスケ,コウスケ,コウスケ,コースケ,,,コウスケ,コウスケタチ,コウスケ達
 2	たち	達	NOUN	接尾辞-名詞的-一般	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タチ,達,たち,たち,タチ,,,タチ,コウスケタチ,コウスケ達
@@ -9388,6 +9740,7 @@
 
 # newdoc id = test-s365
 # sent_id = test-s365
+# parallel_id = jagsd/test365
 # text = 中学卒業後は品茂先生とメル友になり、ヒナノと同じ高校に進学した。
 1	中学	中学	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チュウガク,中学,中学,中学,チューガク,,,チュウガク,チュウガクソツギョウゴ,中学卒業後
 2	卒業	卒業	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ソツギョウ,卒業,卒業,卒業,ソツギョー,,,ソツギョウ,チュウガクソツギョウゴ,中学卒業後
@@ -9412,6 +9765,7 @@
 
 # newdoc id = test-s366
 # sent_id = test-s366
+# parallel_id = jagsd/test366
 # text = 潜水士になる前は会社も嫌になって辞め、親も納得するという理由で海上保安庁に入庁した経緯から、あらゆる境遇に逃げてきていたと自認しているが、仙崎と行動するうちに潜水士としての成長も見せている。
 1	潜水	潜水	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センスイ,潜水,潜水,潜水,センスイ,,,センスイ,センスイシ,潜水士
 2	士	士	NOUN	接尾辞-名詞的-一般	_	4	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シ,士,士,士,シ,,,シ,センスイシ,潜水士
@@ -9482,6 +9836,7 @@
 
 # newdoc id = test-s367
 # sent_id = test-s367
+# parallel_id = jagsd/test367
 # text = また雨が降ると、鉄砲水となって渓谷内を通過していった。
 1	また	又	CCONJ	接続詞	_	15	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	雨	雨	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アメ,雨,雨,雨,アメ,,,アメ,アメ,雨
@@ -9506,6 +9861,7 @@
 
 # newdoc id = test-s368
 # sent_id = test-s368
+# parallel_id = jagsd/test368
 # text = 海老澤代表が統一教会の関係の人か訊くと“いえ,どなたかから聞いたのですか?”
 1	海老澤	海老澤	PROPN	名詞-固有名詞-人名-姓	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=エビサワ,エビサワ,海老澤,海老澤,エビサワ,,,エビサワ,エビサワダイヒョウ,海老澤代表
 2	代表	代表	NOUN	名詞-普通名詞-サ変可能	_	11	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=ダイヒョウ,代表,代表,代表,ダイヒョー,,,ダイヒョウ,エビサワダイヒョウ,海老澤代表
@@ -9535,6 +9891,7 @@
 
 # newdoc id = test-s369
 # sent_id = test-s369
+# parallel_id = jagsd/test369
 # text = 雰囲気がすき!
 1	雰囲気	雰囲気	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=フンイキ,雰囲気,雰囲気,雰囲気,フンイキ,,,フンイキ,フンイキ,雰囲気
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9543,6 +9900,7 @@
 
 # newdoc id = test-s370
 # sent_id = test-s370
+# parallel_id = jagsd/test370
 # text = 私はここの病院に行き、人が怖くなり、外にでれなくなりました。
 1	私	私	PRON	代名詞	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9568,6 +9926,7 @@
 
 # newdoc id = test-s371
 # sent_id = test-s371
+# parallel_id = jagsd/test371
 # text = こうした技術を利用して一台のコンピュータの処理能力を飛躍的に向上させたものはスーパーコンピュータと呼ばれ、複数のコンピュータを統合して全体として処理能力を上げたものはコンピュータ・クラスターと呼ばれる。
 1	こう	こう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=コウ,こう,こう,こう,コー,,,コウ,コウ,こう
 2	し	為る	VERB	動詞-非自立可能-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,スル,する
@@ -9628,6 +9987,7 @@
 
 # newdoc id = test-s372
 # sent_id = test-s372
+# parallel_id = jagsd/test372
 # text = 趣味はソフトボール・マラソン・飲酒。
 1	趣味	趣味	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュミ,趣味,趣味,趣味,シュミ,,,シュミ,シュミ,趣味
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9640,6 +10000,7 @@
 
 # newdoc id = test-s373
 # sent_id = test-s373
+# parallel_id = jagsd/test373
 # text = チチュウカイリクガメ属の模式種。
 1	チチュウ	地中	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チチュウ,地中,チチュウ,チチュウ,チチュー,,,チチュウ,チチュウカイリクガメゾク,地中海陸亀属
 2	カイ	海	NOUN	接尾辞-名詞的-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイ,海,カイ,カイ,カイ,,,カイ,チチュウカイリクガメゾク,地中海陸亀属
@@ -9652,6 +10013,7 @@
 
 # newdoc id = test-s374
 # sent_id = test-s374
+# parallel_id = jagsd/test374
 # text = 自分でも説明できないものを他人に勧めるのはやめてほしいものです。
 1	自分	自分	NOUN	名詞-普通名詞-一般	_	4	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジブン,自分,自分,自分,ジブン,,,ジブン,ジブン,自分
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -9675,6 +10037,7 @@
 
 # newdoc id = test-s375
 # sent_id = test-s375
+# parallel_id = jagsd/test375
 # text = 英語が分からない私でしたが行ってみるとレベルに合わせてクラスが分かれていました。
 1	英語	英語	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エイゴ,英語,英語,英語,エーゴ,,,エイゴ,エイゴ,英語
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -9703,6 +10066,7 @@
 
 # newdoc id = test-s376
 # sent_id = test-s376
+# parallel_id = jagsd/test376
 # text = アドヴァンスの外壁には明日8月6日開催の荒川灯籠流しのポスターが貼ってあった。
 1	アドヴァンス	アドバンス	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アドバンス,アドバンス,アドヴァンス,アドヴァンス,アドバンス,,,アドバンス,アドバンス,アドバンス
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9730,6 +10094,7 @@
 
 # newdoc id = test-s377
 # sent_id = test-s377
+# parallel_id = jagsd/test377
 # text = 店舗の見た目は正直不安をあおるものではありますが、安さと使い勝手は申し分ないと思います。
 1	店舗	店舗	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テンポ,店舗,店舗,店舗,テンポ,,,テンポ,テンポ,店舗
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9763,6 +10128,7 @@
 
 # newdoc id = test-s378
 # sent_id = test-s378
+# parallel_id = jagsd/test378
 # text = よって女子は完全内湯で開放感・景観はゼロでした。
 1	よっ	因る	CCONJ	動詞-一般-五段-ラ行	_	13	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ヨル,因る,よっ,よる,ヨッ,,,ヨル,ヨッテ,因って
 2	て	て	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,ヨッテ,因って
@@ -9783,6 +10149,7 @@
 
 # newdoc id = test-s379
 # sent_id = test-s379
+# parallel_id = jagsd/test379
 # text = 収録曲など詳細は後日発表予定。
 1	収録	収録	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュウロク,収録,収録,収録,シューロク,,,シュウロク,シュウロクキョク,収録曲
 2	曲	曲	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョク,曲,曲,曲,キョク,,,キョク,シュウロクキョク,収録曲
@@ -9796,6 +10163,7 @@
 
 # newdoc id = test-s380
 # sent_id = test-s380
+# parallel_id = jagsd/test380
 # text = 見積もりは出張や電話でしますが、家具の種類と修理項目別におよその見積もりをするフォームがあります。
 1	見積もり	見積もり	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ミツモリ,見積もり,見積もり,見積もり,ミツモリ,,,ミツモリ,ミツモリ,見積もり
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9828,6 +10196,7 @@
 
 # newdoc id = test-s381
 # sent_id = test-s381
+# parallel_id = jagsd/test381
 # text = 血の流れの末端はうなじの下向きに湾曲した線で停止しており、なにか冠のようなものに原因が有るとすれば、茨の枝が後頭部にはまった高さにその線があるように見える。
 1	血	血	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チ,血,血,血,チ,,,チ,チ,血
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -9887,6 +10256,7 @@
 
 # newdoc id = test-s382
 # sent_id = test-s382
+# parallel_id = jagsd/test382
 # text = 戦後は1906年に装甲巡洋艦リューリク艦長に着任。
 1	戦後	戦後	NOUN	名詞-普通名詞-副詞可能	_	12	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=センゴ,戦後,戦後,戦後,センゴ,,,センゴ,センゴ,戦後
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -9904,6 +10274,7 @@
 
 # newdoc id = test-s383
 # sent_id = test-s383
+# parallel_id = jagsd/test383
 # text = 相手GKと1対1になったりだとか、完全にフリーでシュートを打つというのもなかった。
 1	相手	相手	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アイテ,相手,相手,相手,アイテ,,,アイテ,アイテジーケー,相手GK
 2	GK	GK	NOUN	名詞-普通名詞-一般	_	8	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジーケー,ＧＫ,GK,GK,ジーケー,,,ジーケー,アイテジーケー,相手GK
@@ -9935,6 +10306,7 @@
 
 # newdoc id = test-s384
 # sent_id = test-s384
+# parallel_id = jagsd/test384
 # text = 手配書の内容だが,記者の身長も“185cm位”から“180cm位”に修正されている。
 1	手配	手配	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テハイ,手配,手配,手配,テハイ,,,テハイ,テハイショ,手配書
 2	書	書	NOUN	接尾辞-名詞的-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショ,書,書,書,ショ,,,ショ,テハイショ,手配書
@@ -9968,6 +10340,7 @@
 
 # newdoc id = test-s385
 # sent_id = test-s385
+# parallel_id = jagsd/test385
 # text = この写真を掲載しているのは,東京都内の店舗デザイン会社です。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	写真	写真	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シャシン,写真,写真,写真,シャシン,,,シャシン,シャシン,写真
@@ -9990,6 +10363,7 @@
 
 # newdoc id = test-s386
 # sent_id = test-s386
+# parallel_id = jagsd/test386
 # text = ろうそくとアルコールランプを用い、炎の強さや大きさが放射能に当たり、炎からの距離に応じて感じる明るさや温かさは放射線量に当たることを関連づけて学んだ。
 1	ろうそく	蝋燭	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ロウソク,蝋燭,ろうそく,ろうそく,ローソク,,,ロウソク,ロウソク,蝋燭
 2	と	と	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ト,と,と,と,ト,,,ト,ト,と
@@ -10040,6 +10414,7 @@
 
 # newdoc id = test-s387
 # sent_id = test-s387
+# parallel_id = jagsd/test387
 # text = 知っているCMばかり。
 1	知っ	知る	VERB	動詞-一般-五段-ラ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-五段-ラ行|SpaceAfter=No|UnidicInfo=シル,知る,知っ,知る,シッ,,,シル,シル,知る
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助動詞-上一段-ア行|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テイル,ている
@@ -10050,6 +10425,7 @@
 
 # newdoc id = test-s388
 # sent_id = test-s388
+# parallel_id = jagsd/test388
 # text = 古町の老舗店店主から店や町の歴史を聞く「古町老舗・名店巡りコース」や「西大畑・先人の偉業をたどるお屋敷町散歩コース」など12コースあり、一日2コースずつ開く。
 1	古町	古町	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コマチ,古町,古町,古町,コマチ,,,コマチ,コマチ,古町
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10102,6 +10478,7 @@
 
 # newdoc id = test-s389
 # sent_id = test-s389
+# parallel_id = jagsd/test389
 # text = この山寺のアイディアは、後に『ルパン三世風魔一族の陰謀』にて流用される。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	山寺	山寺	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヤマデラ,山寺,山寺,山寺,ヤマデラ,,,ヤマデラ,ヤマデラ,山寺
@@ -10128,6 +10505,7 @@
 
 # newdoc id = test-s390
 # sent_id = test-s390
+# parallel_id = jagsd/test390
 # text = 当時は調騎分離される前だったこともあり、調教師の清水茂次が20戦中19戦に騎乗している。
 1	当時	当時	NOUN	名詞-普通名詞-副詞可能	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウジ,当時,当時,当時,トージ,,,トウジ,トウジ,当時
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10162,6 +10540,7 @@
 
 # newdoc id = test-s392
 # sent_id = test-s392
+# parallel_id = jagsd/test392
 # text = 同化産物は穀粒生産に向け直されるようになり、商業的な収穫のための化学肥料の効果が特に増加する。
 1	同化	同化	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウカ,同化,同化,同化,ドーカ,,,ドウカ,ドウカサンブツ,同化産物
 2	産物	産物	NOUN	名詞-普通名詞-一般	_	11	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サンブツ,産物,産物,産物,サンブツ,,,サンブツ,ドウカサンブツ,同化産物
@@ -10194,6 +10573,7 @@
 
 # newdoc id = test-s393
 # sent_id = test-s393
+# parallel_id = jagsd/test393
 # text = 両親は転勤で北海道に在住しそれが延期となり、姉はまもなく海外へ留学のため親の意向に逆らいマンションを借りて一人暮らしをする。
 1	両親	両親	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=リョウシン,両親,両親,両親,リョーシン,,,リョウシン,リョウシン,両親
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10235,6 +10615,7 @@
 
 # newdoc id = test-s394
 # sent_id = test-s394
+# parallel_id = jagsd/test394
 # text = 同署によると、ドラマの撮影は行われず、違約金も返却されないため、女性が2月に被害を届け出た。
 1	同署	同署	NOUN	名詞-普通名詞-一般	_	30	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウショ,同署,同署,同署,ドーショ,,,ドウショ,ドウショ,同署
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニヨルト,によると
@@ -10271,6 +10652,7 @@
 
 # newdoc id = test-s395
 # sent_id = test-s395
+# parallel_id = jagsd/test395
 # text = 翌12日より五島産業汽船が同航路の運航を開始したが、2006年4月をもって廃止。
 1	翌	翌	NOUN	接頭辞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ヨク,翌,翌,翌,ヨク,,,ヨク,ヨクイチニニチ,翌12日
 2	12	12	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一二,12,12,イチニ,,,イチニ,ヨクイチニニチ,翌12日
@@ -10302,6 +10684,7 @@
 
 # newdoc id = test-s396
 # sent_id = test-s396
+# parallel_id = jagsd/test396
 # text = 翌年に試作機が完成しているが、減速装置の不調と重量過大が最後まで改善されなかった。
 1	翌年	翌年	NOUN	名詞-普通名詞-副詞可能	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨクネン,翌年,翌年,翌年,ヨクネン,,,ヨクネン,ヨクネン,翌年
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -10333,6 +10716,7 @@
 
 # newdoc id = test-s397
 # sent_id = test-s397
+# parallel_id = jagsd/test397
 # text = 食後のラテと小さなデザートもお気に入り。
 1	食後	食後	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショクゴ,食後,食後,食後,ショクゴ,,,ショクゴ,ショクゴ,食後
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10349,6 +10733,7 @@
 
 # newdoc id = test-s398
 # sent_id = test-s398
+# parallel_id = jagsd/test398
 # text = コンピュータにおけるデータログでは、障害などが発生したとき、何が起きたのかを説明できるようにするためにプログラムが自動的にある範囲のイベントを記録する。
 1	コンピュータ	コンピューター	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コンピューター,コンピューター,コンピュータ,コンピュータ,コンピュータ,,,コンピュータ,コンピュータ,コンピュータ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニオケル,における
@@ -10397,6 +10782,7 @@
 
 # newdoc id = test-s399
 # sent_id = test-s399
+# parallel_id = jagsd/test399
 # text = 受付で訊くと展示会は招待制とのことだったが,モバイルHPにその旨の記載がないことを告げると責任者を呼ぶから待つようにと言われた。
 1	受付	受け付け	NOUN	名詞-普通名詞-サ変可能	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ウケツケ,受け付け,受付,受付,ウケツケ,,,ウケツケ,ウケツケ,受け付け
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -10443,6 +10829,7 @@
 
 # newdoc id = test-s400
 # sent_id = test-s400
+# parallel_id = jagsd/test400
 # text = 「MAX11836」はユーザー定義のハプティックパターンのオンチップ保存,再生ロジック,出力設定可能なDC-DC変換,および高い容量性負荷用の出力ドライバを備えている。
 1	「	「	PUNCT	補助記号-括弧開	_	5	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	M	M	NOUN	記号-文字	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=エム,Ｍ,M,M,エム,,,エム,エムエーエックスイチイチハチサンロク,MAX11836
@@ -10490,6 +10877,7 @@
 
 # newdoc id = test-s401
 # sent_id = test-s401
+# parallel_id = jagsd/test401
 # text = 基盤左側に某有名PC周辺機器メーカーのロゴが見えます。
 1	基盤	基盤	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キバン,基盤,基盤,基盤,キバン,,,キバン,キバンヒダリガワ,基盤左側
 2	左側	左側	NOUN	名詞-普通名詞-一般	_	13	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒダリガワ,左側,左側,左側,ヒダリガワ,,,ヒダリガワ,キバンヒダリガワ,基盤左側
@@ -10509,6 +10897,7 @@
 
 # newdoc id = test-s402
 # sent_id = test-s402
+# parallel_id = jagsd/test402
 # text = いよいよイベントもお開きの時間となり、3人は来場者に向け1人ずつコメント。
 1	いよいよ	愈	ADV	副詞	_	9	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イヨイヨ,愈,いよいよ,いよいよ,イヨイヨ,,,イヨイヨ,イヨイヨ,愈
 2	イベント	イベント	NOUN	名詞-普通名詞-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イベント,イベント,イベント,イベント,イベント,,,イベント,イベント,イベント
@@ -10534,6 +10923,7 @@
 
 # newdoc id = test-s403
 # sent_id = test-s403
+# parallel_id = jagsd/test403
 # text = これのお返しとして、寝屋親が寝屋子にごちそうをふるまうことを「寝屋子振舞い」という。
 1	これ	此れ	PRON	代名詞	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10566,6 +10956,7 @@
 
 # newdoc id = test-s404
 # sent_id = test-s404
+# parallel_id = jagsd/test404
 # text = アッシリア王名表では彼の記述の後に「食べつくされる」という注釈がついている。
 1	アッシリア	アッシリア	PROPN	名詞-固有名詞-地名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アッシリア,アッシリア,アッシリア,アッシリア,アッシリア,,,アッシリア,アッシリアオウメイヒョウ,アッシリア王名表
 2	王名	王名	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オウメイ,王名,王名,王名,オーメー,,,オウメイ,アッシリアオウメイヒョウ,アッシリア王名表
@@ -10594,6 +10985,7 @@
 
 # newdoc id = test-s405
 # sent_id = test-s405
+# parallel_id = jagsd/test405
 # text = 女優のランキングでは、20代から30代までの票がいろんな女優にばらけたのに対し、40代から60代までの票が、オードリー・ヘップバーンやマリリン・モンローに集中したことで、上位に往年のハリウッドスターがランキングする結果となりました。
 1	女優	女優	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョユウ,女優,女優,女優,ジョユー,,,ジョユウ,ジョユウ,女優
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10661,6 +11053,7 @@
 
 # newdoc id = test-s406
 # sent_id = test-s406
+# parallel_id = jagsd/test406
 # text = 菅直人首相は28日、円高で加速しかねない産業空洞化を防ぎ、地方を中心に雇用を確保するため、国内への工場立地などの推進を目指す「日本国内投資促進プログラム」の策定を直嶋正行経済産業相に指示した。
 1	菅	菅	PROPN	名詞-固有名詞-人名-姓	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=カン,カン,菅,菅,カン,,,カン,カンナオトシュショウ,菅直人首相
 2	直人	直人	PROPN	名詞-固有名詞-人名-名	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ナオト,ナオト,直人,直人,ナオト,,,ナオト,カンナオトシュショウ,菅直人首相
@@ -10724,6 +11117,7 @@
 
 # newdoc id = test-s407
 # sent_id = test-s407
+# parallel_id = jagsd/test407
 # text = 現在では、観光客も多く訪れるようになっている。
 1	現在	現在	NOUN	名詞-普通名詞-副詞可能	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -10743,6 +11137,7 @@
 
 # newdoc id = test-s408
 # sent_id = test-s408
+# parallel_id = jagsd/test408
 # text = 代わりの人がやったからって上手くできるのかなという感じもあります。
 1	代わり	代わり	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カワリ,代わり,代わり,代わり,カワリ,,,カワリ,カワリ,代わり
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10767,6 +11162,7 @@
 
 # newdoc id = test-s409
 # sent_id = test-s409
+# parallel_id = jagsd/test409
 # text = 創価学会員も参加している運動を“左翼&唯物論”と言われても,意味がよくわかりません。
 1	創価	創価	PROPN	名詞-固有名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ソウカ,創価,創価,創価,ソーカ,,,ソウカ,ソウカガッカイイン,創価学会員
 2	学会	学会	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ガッカイ,学会,学会,学会,ガッカイ,,,ガッカイ,ソウカガッカイイン,創価学会員
@@ -10800,6 +11196,7 @@
 
 # newdoc id = test-s410
 # sent_id = test-s410
+# parallel_id = jagsd/test410
 # text = 無邪気で素直な性格であるが、少し弱虫。
 1	無邪気	無邪気	ADJ	名詞-普通名詞-形状詞可能	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ムジャキ,無邪気,無邪気,無邪気,ムジャキ,,,ムジャキ,ムジャキ,無邪気
 2	で	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,で,だ,デ,,,ダ,ダ,だ
@@ -10816,6 +11213,7 @@
 
 # newdoc id = test-s411
 # sent_id = test-s411
+# parallel_id = jagsd/test411
 # text = 2011年8月に行われた韓国プロ野球ドラフト会議にて、LGツインズより8位指名を受けたが、宋は日本のドラフト会議でも指名の対象になっており、日本でのプレーを希望していることからLGの指名を拒否。
 1	2011	2011	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロ一一,2011,2011,ニゼロイチイチ,,,ニゼロイチイチ,ニゼロイチイチネン,2011年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロイチイチネン,2011年
@@ -10879,6 +11277,7 @@
 
 # newdoc id = test-s412
 # sent_id = test-s412
+# parallel_id = jagsd/test412
 # text = 小田急の通勤車両では初めて他事業者路線への乗り入れを前提とした車両になることから、それまでの小田急の通勤車両の標準仕様とは異なる新技術が採用された。
 1	小田急	小田急	PROPN	名詞-固有名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=オダキュウ,小田急,小田急,小田急,オダキュー,,,オダキュウ,オダキュウ,小田急
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -10929,6 +11328,7 @@
 
 # newdoc id = test-s413
 # sent_id = test-s413
+# parallel_id = jagsd/test413
 # text = 同じく11代目として登場したのが松熊由紀である。
 1	同じく	同じく	ADV	副詞	_	8	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=オナジク,同じく,同じく,同じく,オナジク,,,オナジク,オナジク,同じく
 2	11	11	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一一,11,11,イチイチ,,,イチイチ,イチイチダイメ,11代目
@@ -10950,6 +11350,7 @@
 
 # newdoc id = test-s414
 # sent_id = test-s414
+# parallel_id = jagsd/test414
 # text = 神奈川県横浜市に所在するNPO法人。
 1	神奈川	神奈川	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=カナガワ,カナガワ,神奈川,神奈川,カナガワ,,,カナガワ,カナガワケン,神奈川県
 2	県	県	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ケン,県,県,県,ケン,,,ケン,カナガワケン,神奈川県
@@ -10964,6 +11365,7 @@
 
 # newdoc id = test-s415
 # sent_id = test-s415
+# parallel_id = jagsd/test415
 # text = これはTPが南下される時,神様と約束された南北統一をなすことです。
 1	これ	此れ	PRON	代名詞	_	21	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -10991,6 +11393,7 @@
 
 # newdoc id = test-s416
 # sent_id = test-s416
+# parallel_id = jagsd/test416
 # text = 気軽に立ち寄れるネイルサロンなので、初めての人でも是非通ってみてください。
 1	気軽	気軽	ADJ	形状詞-一般	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=キガル,気軽,気軽,気軽,キガル,,,キガル,キガル,気軽
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -11016,6 +11419,7 @@
 
 # newdoc id = test-s418
 # sent_id = test-s418
+# parallel_id = jagsd/test418
 # text = ヒットメーカーに当たりが出ない。
 1	ヒット	ヒット	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒット,ヒット,ヒット,ヒット,ヒット,,,ヒット,ヒットメーカー,ヒットメーカー
 2	メーカー	メーカー	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=メーカー,メーカー,メーカー,メーカー,メーカー,,,メーカー,ヒットメーカー,ヒットメーカー
@@ -11028,6 +11432,7 @@
 
 # newdoc id = test-s419
 # sent_id = test-s419
+# parallel_id = jagsd/test419
 # text = 私は“あるんだ”という以外ないので,議論になります。
 1	私	私	PRON	代名詞	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ワタシ,私,私,私,ワタシ,,,ワタシ,ワタシ,私
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11051,6 +11456,7 @@
 
 # newdoc id = test-s420
 # sent_id = test-s420
+# parallel_id = jagsd/test420
 # text = デドフスクにはM9幹線道路が通るほか、モスクワからリガに向かう鉄道も通る。
 1	デドフスク	デドフスク	PROPN	名詞-固有名詞-地名-一般	_	19	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=デドフスク,デドフスク,デドフスク,デドフスク,デドフスク,,,デドフスク,デドフスク,デドフスク
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -11075,6 +11481,7 @@
 
 # newdoc id = test-s421
 # sent_id = test-s421
+# parallel_id = jagsd/test421
 # text = 日置藩領主。
 1	日置	日置	PROPN	名詞-固有名詞-地名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒオキ,ヒオキ,日置,日置,ヒオキ,,,ヒオキ,ヒオキハンリョウシュ,日置藩領主
 2	藩	藩	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハン,藩,藩,藩,ハン,,,ハン,ヒオキハンリョウシュ,日置藩領主
@@ -11083,6 +11490,7 @@
 
 # newdoc id = test-s422
 # sent_id = test-s422
+# parallel_id = jagsd/test422
 # text = 一旦はその考えを受け入れたが、CNRT率いる野党連合とフレティリンは、何週間も論争を繰り返したが合意には至らなかった。
 1	一旦	一旦	ADV	副詞	_	6	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イッタン,一旦,一旦,一旦,イッタン,,,イッタン,イッタン,一旦
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11119,6 +11527,7 @@
 
 # newdoc id = test-s423
 # sent_id = test-s423
+# parallel_id = jagsd/test423
 # text = 1635年か36年にアントワープの画家組合に加入。
 1	1635	1635	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一六三五,1635,1635,イチロクサンゴ,,,イチロクサンゴ,イチロクサンゴネン,1635年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチロクサンゴネン,1635年
@@ -11136,6 +11545,7 @@
 
 # newdoc id = test-s424
 # sent_id = test-s424
+# parallel_id = jagsd/test424
 # text = 2004年の推計では100,771人に減少している。
 1	2004	2004	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ四,2004,2004,ニゼロゼロヨ,,,ニゼロゼロヨ,ニゼロゼロヨンネン,2004年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロヨンネン,2004年
@@ -11156,6 +11566,7 @@
 
 # newdoc id = test-s425
 # sent_id = test-s425
+# parallel_id = jagsd/test425
 # text = 2007年3月にFIFA女子ワールドカップの出場権をかけた大陸間プレーオフで2003年と同様にメキシコとホーム・アンド・アウェーで対戦。
 1	2007	2007	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ七,2007,2007,ニゼロゼロシチ,,,ニゼロゼロシチ,ニゼロゼロシチネン,2007年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロシチネン,2007年
@@ -11195,6 +11606,7 @@
 
 # newdoc id = test-s426
 # sent_id = test-s426
+# parallel_id = jagsd/test426
 # text = 御手洗学園高等部入学直後にミステリー執筆技術を実践的に習えるものと勘違いし、実践ミステリ倶楽部に仮入部する。
 1	御手洗	御手洗	PROPN	名詞-固有名詞-人名-姓	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ミタライ,ミタライ,御手洗,御手洗,ミタライ,,,ミタライ,ミタライガクエンコウトウブニュウガクチョクゴ,御手洗学園高等部入学直後
 2	学園	学園	NOUN	名詞-普通名詞-一般	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ガクエン,学園,学園,学園,ガクエン,,,ガクエン,ミタライガクエンコウトウブニュウガクチョクゴ,御手洗学園高等部入学直後
@@ -11227,6 +11639,7 @@
 
 # newdoc id = test-s427
 # sent_id = test-s427
+# parallel_id = jagsd/test427
 # text = 発表会などのイベントでは、生徒さんたちの演奏だけでなく、講師陣のセッションもかなり見応えがあります♪
 1	発表	発表	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハッピョウ,発表,発表,発表,ハッピョー,,,ハッピョウ,ハッピョウカイ,発表会
 2	会	会	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイ,会,会,会,カイ,,,カイ,ハッピョウカイ,発表会
@@ -11259,6 +11672,7 @@
 
 # newdoc id = test-s428
 # sent_id = test-s428
+# parallel_id = jagsd/test428
 # text = 国民運動連合所属。
 1	国民	国民	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コクミン,国民,国民,国民,コクミン,,,コクミン,コクミンウンドウレンゴウショゾク,国民運動連合所属
 2	運動	運動	NOUN	名詞-普通名詞-サ変可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ウンドウ,運動,運動,運動,ウンドー,,,ウンドウ,コクミンウンドウレンゴウショゾク,国民運動連合所属
@@ -11268,6 +11682,7 @@
 
 # newdoc id = test-s429
 # sent_id = test-s429
+# parallel_id = jagsd/test429
 # text = まもなくしてミトライはラテンアメリカの芸術・文化に魅了されはじめた。
 1	ま	間	NOUN	名詞-普通名詞-助数詞可能	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=マ,間,ま,ま,マ,,,マ,マ,間
 2	も	も	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=モ,も,も,も,モ,,,モ,モ,も
@@ -11291,6 +11706,7 @@
 
 # newdoc id = test-s430
 # sent_id = test-s430
+# parallel_id = jagsd/test430
 # text = そこで、うなぎ屋が山伏を追っかけてその通りに言うと「わしゃ。
 1	そこ	其処	PRON	代名詞	_	8	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ソコ,其処,そこ,そこ,ソコ,,,ソコ,ソコ,其処
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -11312,6 +11728,7 @@
 
 # newdoc id = test-s431
 # sent_id = test-s431
+# parallel_id = jagsd/test431
 # text = 正午からのデモでは,紀尾井町の文芸春秋本社通用門前に30名程の信者が並び,初日からリーダーを務める井口氏の号令で一人ずつビルに向かい抗議の演説。
 1	正午	正午	NOUN	名詞-普通名詞-副詞可能	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショウゴ,正午,正午,正午,ショーゴ,,,ショウゴ,ショウゴ,正午
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -11359,6 +11776,7 @@
 
 # newdoc id = test-s432
 # sent_id = test-s432
+# parallel_id = jagsd/test432
 # text = 同大統領は、EU加盟および欧州統合を目指す意向を表明した。
 1	同	同	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウ,同,同,同,ドー,,,ドウ,ドウダイトウリョウ,同大統領
 2	大統領	大統領	NOUN	名詞-普通名詞-一般	_	14	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダイトウリョウ,大統領,大統領,大統領,ダイトーリョー,,,ダイトウリョウ,ドウダイトウリョウ,同大統領
@@ -11380,6 +11798,7 @@
 
 # newdoc id = test-s433
 # sent_id = test-s433
+# parallel_id = jagsd/test433
 # text = したがって、横滑り側の片翼の揚力が反対側よりも大きくなり、エルロン操作を行なわなくとも傾きは回復する。
 1	したがっ	従う	CCONJ	動詞-一般-五段-ワア行	_	26	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シタガウ,従う,したがっ,したがう,シタガッ,,,シタガウ,シタガッテ,従って
 2	て	て	SCONJ	助詞-接続助詞	_	1	fixed	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,シタガッテ,従って
@@ -11412,6 +11831,7 @@
 
 # newdoc id = test-s434
 # sent_id = test-s434
+# parallel_id = jagsd/test434
 # text = その理由は“科学の無視”です。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	理由	理由	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=リユウ,理由,理由,理由,リユー,,,リユウ,リユウ,理由
@@ -11426,6 +11846,7 @@
 
 # newdoc id = test-s435
 # sent_id = test-s435
+# parallel_id = jagsd/test435
 # text = 艦名はエイの一種であるスケートに因む。
 1	艦名	艦名	NOUN	名詞-普通名詞-一般	_	10	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カンメイ,艦名,艦名,艦名,カンメー,,,カンメイ,カンメイ,艦名
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11441,6 +11862,7 @@
 
 # newdoc id = test-s436
 # sent_id = test-s436
+# parallel_id = jagsd/test436
 # text = 脱線の原因は不明で、地元の消防局は、煙に有害物質が含まれている可能性があると周辺の住民に注意を呼びかけている。
 1	脱線	脱線	NOUN	名詞-普通名詞-サ変可能	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダッセン,脱線,脱線,脱線,ダッセン,,,ダッセン,ダッセン,脱線
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11482,6 +11904,7 @@
 
 # newdoc id = test-s437
 # sent_id = test-s437
+# parallel_id = jagsd/test437
 # text = こうしたことは、後の大洪水時代においても同様であり、貴族共和制の弱点を突かれたと言える。
 1	こう	こう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=コウ,こう,こう,こう,コー,,,コウ,コウ,こう
 2	し	為る	VERB	動詞-非自立可能-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,スル,する
@@ -11517,6 +11940,7 @@
 
 # newdoc id = test-s438
 # sent_id = test-s438
+# parallel_id = jagsd/test438
 # text = 安徽省安慶出身。
 1	安徽	安徽	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=アンキ,アンキ,安徽,安徽,アンキ,,,アンキ,アンキショウ,安徽省
 2	省	省	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ショウ,省,省,省,ショー,,,ショウ,アンキショウ,安徽省
@@ -11526,6 +11950,7 @@
 
 # newdoc id = test-s439
 # sent_id = test-s439
+# parallel_id = jagsd/test439
 # text = ペリューは、1804年に少将に昇進した。
 1	ペリュー	ペリュー	PROPN	名詞-固有名詞-人名-一般	_	9	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ペリー,ペリー,ペリュー,ペリュー,ペリュー,,,ペリュー,ペリュー,ペリュー
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11542,6 +11967,7 @@
 
 # newdoc id = test-s440
 # sent_id = test-s440
+# parallel_id = jagsd/test440
 # text = グレズリー式連動弁装置は実質上は付加装置であって、外側二気筒の弁装置の位置を逆向きに合成して中央シリンダーの弁位置を決めている。
 1	グレズリー	グレズリー	PROPN	名詞-固有名詞-人名-一般	_	5	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=グレズリー,グレズリー,グレズリー,グレズリー,グレズリー,,,グレズリー,グレズリーシキレンドウベンソウチ,グレズリー式連動弁装置
 2	式	式	NOUN	接尾辞-名詞的-一般	_	5	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シキ,式,式,式,シキ,,,シキ,グレズリーシキレンドウベンソウチ,グレズリー式連動弁装置
@@ -11585,6 +12011,7 @@
 
 # newdoc id = test-s441
 # sent_id = test-s441
+# parallel_id = jagsd/test441
 # text = 目標が超音速飛行している場合においても、その時だけ短時間飛行できれば問題無く、長時間の超音速飛行によって追尾する必要は無いからである。
 1	目標	目標	NOUN	名詞-普通名詞-一般	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=モクヒョウ,目標,目標,目標,モクヒョー,,,モクヒョウ,モクヒョウ,目標
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -11632,6 +12059,7 @@
 
 # newdoc id = test-s442
 # sent_id = test-s442
+# parallel_id = jagsd/test442
 # text = 新快速の運行時間外などは快速としても運用され、稀に湘南色との混色編成などもあった。
 1	新	新	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シン,新,新,新,シン,,,シン,シンカイソク,新快速
 2	快速	快速	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイソク,快速,快速,快速,カイソク,,,カイソク,シンカイソク,新快速
@@ -11666,6 +12094,7 @@
 
 # newdoc id = test-s443
 # sent_id = test-s443
+# parallel_id = jagsd/test443
 # text = 13歳の頃から数々の舞台に出演しており、アル・パチーノとの共演歴もある。
 1	13	13	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一三,13,13,イチサン,,,イチサン,イチサンサイ,13歳
 2	歳	歳	NOUN	接尾辞-名詞的-助数詞	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=サイ,歳,歳,歳,サイ,,,サイ,イチサンサイ,13歳
@@ -11694,6 +12123,7 @@
 
 # newdoc id = test-s444
 # sent_id = test-s444
+# parallel_id = jagsd/test444
 # text = 当初、民主党の西村智奈美が「審議に100時間は必要だ」と主張し、与党側も「重要法案」指定を見送ったことから、第171回国会での公文書管理法の成立は絶望視されていた。
 1	当初	当初	ADV	名詞-普通名詞-副詞可能	_	19	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=トウショ,当初,当初,当初,トーショ,,,トウショ,トウショ,当初
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -11754,6 +12184,7 @@
 
 # newdoc id = test-s445
 # sent_id = test-s445
+# parallel_id = jagsd/test445
 # text = 神奈川県鎌倉市北鎌倉出身。
 1	神奈川	神奈川	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=カナガワ,カナガワ,神奈川,神奈川,カナガワ,,,カナガワ,カナガワケン,神奈川県
 2	県	県	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ケン,県,県,県,ケン,,,ケン,カナガワケン,神奈川県
@@ -11766,6 +12197,7 @@
 
 # newdoc id = test-s446
 # sent_id = test-s446
+# parallel_id = jagsd/test446
 # text = 唯一、最初から冥術を使用できるクラス。
 1	唯一	唯一	ADV	名詞-普通名詞-副詞可能	_	7	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ユイイツ,唯一,唯一,唯一,ユイイツ,,,ユイイツ,ユイイツ,唯一
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -11780,6 +12212,7 @@
 
 # newdoc id = test-s447
 # sent_id = test-s447
+# parallel_id = jagsd/test447
 # text = 1883年に家族に連れられてドイツに移住。
 1	1883	1883	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一八八三,1883,1883,イチハチハチサン,,,イチハチハチサン,イチハチハチサンネン,1883年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	11	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,イチハチハチサンネン,1883年
@@ -11796,6 +12229,7 @@
 
 # newdoc id = test-s448
 # sent_id = test-s448
+# parallel_id = jagsd/test448
 # text = 味は申し分ない。
 1	味	味	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アジ,味,味,味,アジ,,,アジ,アジ,味
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11805,6 +12239,7 @@
 
 # newdoc id = test-s449
 # sent_id = test-s449
+# parallel_id = jagsd/test449
 # text = そして5月にリリースした「Story」は8位初登場の後、売上枚数30万枚、ダウンロード件数400万件となり、同曲で初のNHK紅白歌合戦出場を果す。
 1	そして	そして	CCONJ	接続詞	_	43	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=ソシテ,そして,そして,そして,ソシテ,,,ソシテ,ソシテ,そして
 2	5	5	NUM	名詞-数詞	_	3	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ゴ,五,5,5,ゴ,,,ゴ,ゴガツ,5月
@@ -11853,6 +12288,7 @@
 
 # newdoc id = test-s450
 # sent_id = test-s450
+# parallel_id = jagsd/test450
 # text = 詳細は槍槓を参照。
 1	詳細	詳細	NOUN	名詞-普通名詞-形状詞可能	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ショウサイ,詳細,詳細,詳細,ショーサイ,,,ショウサイ,ショウサイ,詳細
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11863,6 +12299,7 @@
 
 # newdoc id = test-s451
 # sent_id = test-s451
+# parallel_id = jagsd/test451
 # text = プードルの女の子のキャラクター。
 1	プードル	プードル	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=プードル,プードル,プードル,プードル,プードル,,,プードル,プードル,プードル
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -11873,6 +12310,7 @@
 
 # newdoc id = test-s452
 # sent_id = test-s452
+# parallel_id = jagsd/test452
 # text = 僕ができるのはクルマのフィードバックだけ。
 1	僕	僕	PRON	代名詞	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=ボク,僕,僕,僕,ボク,,,ボク,ボク,僕
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -11887,6 +12325,7 @@
 
 # newdoc id = test-s453
 # sent_id = test-s453
+# parallel_id = jagsd/test453
 # text = バスは園児19人と運転手、幼稚園の職員の計21人が乗車し、幼稚園に向かう途中だった。
 1	バス	バス	NOUN	名詞-普通名詞-一般	_	26	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=バス,バス,バス,バス,バス,,,バス,バス,バス
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -11920,6 +12359,7 @@
 
 # newdoc id = test-s454
 # sent_id = test-s454
+# parallel_id = jagsd/test454
 # text = 一般的にハニー・ライトニング・フレアより威力が高い。
 1	一般	一般	NOUN	名詞-普通名詞-一般	_	12	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=イッパン,一般,一般,一般,イッパン,,,イッパン,イッパンテキ,一般的
 2	的	的	PART	接尾辞-形状詞的	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=テキ,的,的,的,テキ,,,テキ,イッパンテキ,一般的
@@ -11937,6 +12377,7 @@
 
 # newdoc id = test-s455
 # sent_id = test-s455
+# parallel_id = jagsd/test455
 # text = この地形を利用している生物がアキアカネである。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	地形	地形	NOUN	名詞-普通名詞-一般	_	4	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チケイ,地形,地形,地形,チケー,,,チケイ,チケイ,地形
@@ -11954,6 +12395,7 @@
 
 # newdoc id = test-s456
 # sent_id = test-s456
+# parallel_id = jagsd/test456
 # text = 14日未明、ジャーヴィスはスペイン艦隊が風上35マイルにあることを知った。
 1	14	14	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=イチ,一四,14,14,イチヨッ,,,イチヨ,イチヨンカミメイ,14日未明
 2	日	日	NOUN	接尾辞-名詞的-助数詞	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=カ,日,日,日,カ,,,カ,イチヨンカミメイ,14日未明
@@ -11977,6 +12419,7 @@
 
 # newdoc id = test-s457
 # sent_id = test-s457
+# parallel_id = jagsd/test457
 # text = 考え方の源流は、アルキメデスが円周率の近似値を計算する際に用いた方法にまで遡るが、現代的な形での定式化はガウスによってなされた。
 1	考え	考える	VERB	動詞-一般-下一段-ア行	_	2	nmod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カンガエル,考える,考え,考える,カンガエ,,,カンガエル,カンガエカタ,考え方
 2	方	方	NOUN	接尾辞-名詞的-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カタ,方,方,方,カタ,,,カタ,カンガエカタ,考え方
@@ -12024,6 +12467,7 @@
 
 # newdoc id = test-s458
 # sent_id = test-s458
+# parallel_id = jagsd/test458
 # text = 非常に楽しみです。
 1	非常	非常	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ヒジョウ,非常,非常,非常,ヒジョー,,,ヒジョウ,ヒジョウ,非常
 2	に	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,に,だ,ニ,,,ダ,ダ,だ
@@ -12033,6 +12477,7 @@
 
 # newdoc id = test-s459
 # sent_id = test-s459
+# parallel_id = jagsd/test459
 # text = MVPは打率.450、2本塁打、6打点の成績をあげたアラン・トランメルが初選出。
 1	MVP	MVP	NOUN	名詞-普通名詞-一般	_	23	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=エムブイピー,ＭＶＰ,MVP,MVP,エムブイピー,,,エムブイピー,エムブイピー,MVP
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12061,6 +12506,7 @@
 
 # newdoc id = test-s460
 # sent_id = test-s460
+# parallel_id = jagsd/test460
 # text = ラジカルは反応性が高く、生物学的環境ではたいていの場合あまり高濃度では存在せず、ラジカルに1電子を奪われた分子が他の分子から電子を引き抜くとその分子がさらにラジカルを形成するので反応は連鎖的に進行する。
 1	ラジカル	ラジカル	NOUN	名詞-普通名詞-一般	_	22	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ラジカル,ラジカル,ラジカル,ラジカル,ラジカル,,,ラジカル,ラジカル,ラジカル
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12126,6 +12572,7 @@
 
 # newdoc id = test-s461
 # sent_id = test-s461
+# parallel_id = jagsd/test461
 # text = 会社の業務もナイフや刀剣の売買が主体となるが、いずれの名称も同好会的な誤解を生じ易いため、そうした誤解を上手く利用して業績を上げたようである。
 1	会社	会社	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイシャ,会社,会社,会社,カイシャ,,,カイシャ,カイシャ,会社
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12176,6 +12623,7 @@
 
 # newdoc id = test-s462
 # sent_id = test-s462
+# parallel_id = jagsd/test462
 # text = これは、学校教育や大手新聞やテレビや書籍で、「日本は韓国の優れた文化を受け入れるだけの文化劣等国」「有史以来一枚見下げるべき文化的劣等者」「韓半島に比べてみすぼらしくて短い歴史しか持たず、歴史を捏造するしかない日本」というような対日蔑視に基づいた誤った論評が日常的に行われたり、日本列島を指す「島国」という言葉が「劣等で未開」という意味で使われて、駐日韓国大使がテレビのインタビューで使うまでになっていることからも伺える。
 1	これ	此れ	PRON	代名詞	_	126	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12307,6 +12755,7 @@
 
 # newdoc id = test-s463
 # sent_id = test-s463
+# parallel_id = jagsd/test463
 # text = 同校は1923年に創立された、ヒューストンでは最も長い歴史を誇る法学校で、模擬裁判プログラムがつとに良く知られている。
 1	同校	同校	NOUN	名詞-普通名詞-一般	_	29	nsubj:outer	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウコウ,同校,同校,同校,ドーコー,,,ドウコウ,ドウコウ,同校
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12344,6 +12793,7 @@
 
 # newdoc id = test-s464
 # sent_id = test-s464
+# parallel_id = jagsd/test464
 # text = 横須賀線への転属後、主電動機を強力形に交換した7両が新形式のモハ53形を付与された。
 1	横須賀	横須賀	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨコスカ,ヨコスカ,横須賀,横須賀,ヨコスカ,,,ヨコスカ,ヨコスカセン,横須賀線
 2	線	線	NOUN	接尾辞-名詞的-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セン,線,線,線,セン,,,セン,ヨコスカセン,横須賀線
@@ -12381,6 +12831,7 @@
 
 # newdoc id = test-s465
 # sent_id = test-s465
+# parallel_id = jagsd/test465
 # text = 変更点の詳細については、タイムクライシス4の項を参照のこと。
 1	変更	変更	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヘンコウ,変更,変更,変更,ヘンコー,,,ヘンコウ,ヘンコウテン,変更点
 2	点	点	NOUN	名詞-普通名詞-助数詞可能	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テン,点,点,点,テン,,,テン,ヘンコウテン,変更点
@@ -12404,6 +12855,7 @@
 
 # newdoc id = test-s466
 # sent_id = test-s466
+# parallel_id = jagsd/test466
 # text = 一部で9月中間期の連結営業利益が36億円前後と前年同期比35%程度増えたようだと伝えられたことが買い材料となった。
 1	一部	一部	NOUN	名詞-普通名詞-副詞可能	_	28	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イチブ,一部,一部,一部,イチブ,,,イチブ,イチブ,一部
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -12446,6 +12898,7 @@
 
 # newdoc id = test-s467
 # sent_id = test-s467
+# parallel_id = jagsd/test467
 # text = 便宜的に分類したがもちろん複数のケースにまたがった適応を示す動物も多い。
 1	便宜	便宜	ADJ	名詞-普通名詞-形状詞可能	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ベンギ,便宜,便宜,便宜,ベンギ,,,ベンギ,ベンギテキ,便宜的
 2	的	的	PART	接尾辞-形状詞的	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=テキ,的,的,的,テキ,,,テキ,ベンギテキ,便宜的
@@ -12471,6 +12924,7 @@
 
 # newdoc id = test-s468
 # sent_id = test-s468
+# parallel_id = jagsd/test468
 # text = 12月2日の午後、ドイツ空軍パイロット、ヴェルナー・ハーンはMe210でバーリを上空から偵察した。
 1	12	12	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一二,12,12,イチニ,,,イチニ,イチニガツ,12月
 2	月	月	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ガツ,月,月,月,ガツ,,,ガツ,イチニガツ,12月
@@ -12501,6 +12955,7 @@
 
 # newdoc id = test-s469
 # sent_id = test-s469
+# parallel_id = jagsd/test469
 # text = 暴騰する食料価格や大災害で人心は荒廃し、食料目当ての暴動や若者の退廃が進行。
 1	暴騰	暴騰	VERB	名詞-普通名詞-サ変可能	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=ボウトウ,暴騰,暴騰,暴騰,ボートー,,,ボウトウ,ボウトウスル,暴騰する
 2	する	為る	AUX	動詞-非自立可能-サ行変格	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,する,する,スル,,,スル,ボウトウスル,暴騰する
@@ -12529,6 +12984,7 @@
 
 # newdoc id = test-s470
 # sent_id = test-s470
+# parallel_id = jagsd/test470
 # text = 幸福の科学学園の毎時4.20マイクロシーベルトというこの基準を上回ります。
 1	幸福	幸福	NOUN	名詞-普通名詞-形状詞可能	_	14	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=コウフク,幸福,幸福,幸福,コーフク,,,コウフク,コウフクノカガクガクエン,幸福の科学学園
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=I|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,コウフクノカガクガクエン,幸福の科学学園
@@ -12551,6 +13007,7 @@
 
 # newdoc id = test-s471
 # sent_id = test-s471
+# parallel_id = jagsd/test471
 # text = 長時間拘束され半軟禁状態の女性もいた。
 1	長	長	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=チョウ,長,長,長,チョー,,,チョウ,チョウジカン,長時間
 2	時間	時間	NOUN	名詞-普通名詞-助数詞可能	_	3	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ジカン,時間,時間,時間,ジカン,,,ジカン,チョウジカン,長時間
@@ -12569,6 +13026,7 @@
 
 # newdoc id = test-s472
 # sent_id = test-s472
+# parallel_id = jagsd/test472
 # text = 同発電所は老朽化した小規模の発電所で、警備は手薄だった。
 1	同	同	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドウ,同,同,同,ドー,,,ドウ,ドウハツデンショ,同発電所
 2	発電	発電	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハツデン,発電,発電,発電,ハツデン,,,ハツデン,ドウハツデンショ,同発電所
@@ -12594,6 +13052,7 @@
 
 # newdoc id = test-s473
 # sent_id = test-s473
+# parallel_id = jagsd/test473
 # text = 回転ジェットによる体当たり攻撃。
 1	回転	回転	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイテン,回転,回転,回転,カイテン,,,カイテン,カイテンジェット,回転ジェット
 2	ジェット	ジェット	NOUN	名詞-普通名詞-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジェット,ジェット,ジェット,ジェット,ジェット,,,ジェット,カイテンジェット,回転ジェット
@@ -12605,6 +13064,7 @@
 
 # newdoc id = test-s474
 # sent_id = test-s474
+# parallel_id = jagsd/test474
 # text = 屋根のアンテナにカラスが止まっていたずらをするし、屋根が汚れてこまるからと、調査の依頼がありました。
 1	屋根	屋根	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヤネ,屋根,屋根,屋根,ヤネ,,,ヤネ,ヤネ,屋根
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -12638,6 +13098,7 @@
 
 # newdoc id = test-s475
 # sent_id = test-s475
+# parallel_id = jagsd/test475
 # text = そのカステラは,表面に“祝3.16広宣流布記念の日”と印字されており,これを買うと,創価学会のシンボルである3色デザインの紙袋に入れてくれます。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	カステラ	カステラ	NOUN	名詞-普通名詞-一般	_	19	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カステラ,カステラ,カステラ,カステラ,カステラ,,,カステラ,カステラ,カステラ
@@ -12688,6 +13149,7 @@
 
 # newdoc id = test-s476
 # sent_id = test-s476
+# parallel_id = jagsd/test476
 # text = 13世紀の建築は1456年から1466年にかけて新しいサンクチュアリに合うように改築された。
 1	13	13	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イチ,一三,13,13,イチサン,,,イチサン,イチサンセイキ,13世紀
 2	世紀	世紀	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=セイキ,世紀,世紀,世紀,セーキ,,,セイキ,イチサンセイキ,13世紀
@@ -12716,6 +13178,7 @@
 
 # newdoc id = test-s477
 # sent_id = test-s477
+# parallel_id = jagsd/test477
 # text = インクは、大きく分けてビン入りとカートリッジ入りの2種類の形態で流通している。
 1	インク	インク	NOUN	名詞-普通名詞-一般	_	18	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=インク,インク,インク,インク,インク,,,インク,インク,インク
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12742,6 +13205,7 @@
 
 # newdoc id = test-s478
 # sent_id = test-s478
+# parallel_id = jagsd/test478
 # text = 勧誘員と勧誘対象者。
 1	勧誘	勧誘	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カンユウ,勧誘,勧誘,勧誘,カンユー,,,カンユウ,カンユウイン,勧誘員
 2	員	員	NOUN	接尾辞-名詞的-一般	_	6	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イン,員,員,員,イン,,,イン,カンユウイン,勧誘員
@@ -12753,6 +13217,7 @@
 
 # newdoc id = test-s479
 # sent_id = test-s479
+# parallel_id = jagsd/test479
 # text = また、攻撃手法としてはJava Scriptの難読化による手口や、PDFを利用した攻撃が引き続き増加しており、フィッシング詐欺の発生件数は2009年のピーク時に比べて82%減少したが、依然として金融機関が主要ターゲットとして脅威に晒されているとしている。
 1	また	又	CCONJ	接続詞	_	72	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -12832,6 +13297,7 @@
 
 # newdoc id = test-s480
 # sent_id = test-s480
+# parallel_id = jagsd/test480
 # text = これがまた,うまい。
 1	これ	此れ	PRON	代名詞	_	5	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -12842,6 +13308,7 @@
 
 # newdoc id = test-s481
 # sent_id = test-s481
+# parallel_id = jagsd/test481
 # text = 艦長は、爆薬をリモコンによる遠隔操作で爆発させて艦内の機材や機密文書等を爆破処分し、証拠を隠滅しようとしたが、効果は不十分に終わった。
 1	艦長	艦長	NOUN	名詞-普通名詞-一般	_	33	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カンチョウ,艦長,艦長,艦長,カンチョー,,,カンチョウ,カンチョウ,艦長
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12890,6 +13357,7 @@
 
 # newdoc id = test-s482
 # sent_id = test-s482
+# parallel_id = jagsd/test482
 # text = アイドルユニットとしても売り出され、フリーランスになってからは主演Vシネマの主題歌CDもだし、歌手デビューも果たす。
 1	アイドル	アイドル	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アイドル,アイドル,アイドル,アイドル,アイドル,,,アイドル,アイドルユニット,アイドルユニット
 2	ユニット	ユニット	NOUN	名詞-普通名詞-一般	_	7	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ユニット,ユニット,ユニット,ユニット,ユニット,,,ユニット,アイドルユニット,アイドルユニット
@@ -12924,6 +13392,7 @@
 
 # newdoc id = test-s483
 # sent_id = test-s483
+# parallel_id = jagsd/test483
 # text = 毛布にくるまって寒さをしのぎ、おにぎり1個を家族4人で分け合った。
 1	毛布	毛布	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=モウフ,毛布,毛布,毛布,モーフ,,,モウフ,モウフ,毛布
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -12948,6 +13417,7 @@
 
 # newdoc id = test-s484
 # sent_id = test-s484
+# parallel_id = jagsd/test484
 # text = 動きは緩慢だが常にスーパーアーマー状態であり、ほとんどの攻撃を受けてもひるまない。
 1	動き	動き	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ウゴキ,動き,動き,動き,ウゴキ,,,ウゴキ,ウゴキ,動き
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -12975,6 +13445,7 @@
 
 # newdoc id = test-s485
 # sent_id = test-s485
+# parallel_id = jagsd/test485
 # text = よく見ると、背中や腹にあるぶち模様がいずれもハートの形をしており「体全体にハートがある猫」と口コミで広がったという。
 1	よく	良く	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=ヨク,良く,よく,よく,ヨク,,,ヨク,ヨク,良く
 2	見る	見る	VERB	動詞-非自立可能-上一段-マ行	_	19	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-上一段-マ行|PrevUDLemma=みる|SpaceAfter=No|UnidicInfo=ミル,見る,見る,見る,ミル,,,ミル,ミル,見る
@@ -13017,6 +13488,7 @@
 
 # newdoc id = test-s486
 # sent_id = test-s486
+# parallel_id = jagsd/test486
 # text = タダで留学生が韓国料理をふるまい,韓国語も教えるので,日本語を教えてもらったり,友達になってもらいたい。
 1	タダ	只	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タダ,只,タダ,タダ,タダ,,,タダ,タダ,只
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -13053,6 +13525,7 @@
 
 # newdoc id = test-s487
 # sent_id = test-s487
+# parallel_id = jagsd/test487
 # text = 「VANITY DANCE」と「Labyrinth」は、オムニバスアルバム『漆黒のシンフォニー』に収録されたもののリミックスバージョンである。
 1	「	「	PUNCT	補助記号-括弧開	_	3	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	VANITY	VANITY	NOUN	名詞-普通名詞-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|UnidicInfo=バニティ,バニティ,VANITY,,バニティ,,,バニティ,バニティダンス,VANITYDANCE
@@ -13086,6 +13559,7 @@
 
 # newdoc id = test-s488
 # sent_id = test-s488
+# parallel_id = jagsd/test488
 # text = そのうちの幾つかはイギリス当局がケニア人を抑圧した方法をそのまま転用したものだった。
 1	その	其の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=ソノ,其の,その,その,ソノ,,,ソノ,ソノ,其の
 2	うち	内	NOUN	名詞-普通名詞-副詞可能	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ウチ,内,うち,うち,ウチ,,,ウチ,ウチ,家
@@ -13117,6 +13591,7 @@
 
 # newdoc id = test-s489
 # sent_id = test-s489
+# parallel_id = jagsd/test489
 # text = 縦に並ぶ4門の砲台から、それぞれバウンド弾、ブーメラン弾、誘導弾、レーザーを発射する。
 1	縦	縦	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=タテ,縦,縦,縦,タテ,,,タテ,タテ,縦
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -13145,6 +13620,7 @@
 
 # newdoc id = test-s490
 # sent_id = test-s490
+# parallel_id = jagsd/test490
 # text = 木炭デッサンにおいて消しゴムは硬くて紙を傷めるために使用できず、柔らかく油分の少ない食パンを代用している。
 1	木炭	木炭	NOUN	名詞-普通名詞-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=モクタン,木炭,木炭,木炭,モクタン,,,モクタン,モクタンデッサン,木炭デッサン
 2	デッサン	デッサン	NOUN	名詞-普通名詞-サ変可能	_	27	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=デッサン,デッサン,デッサン,デッサン,デッサン,,,デッサン,モクタンデッサン,木炭デッサン
@@ -13180,6 +13656,7 @@
 
 # newdoc id = test-s491
 # sent_id = test-s491
+# parallel_id = jagsd/test491
 # text = 大変,卑怯といわざるをえない。
 1	大変	大変	ADV	副詞	_	3	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=タイヘン,大変,大変,大変,タイヘン,,,タイヘン,タイヘン,大変
 2	,	,	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,，,",",",",,,,,,，
@@ -13194,6 +13671,7 @@
 
 # newdoc id = test-s492
 # sent_id = test-s492
+# parallel_id = jagsd/test492
 # text = いろんなメニューがあり、どんどん頼みたくなっちゃいますね!
 1	いろんな	色んな	ADJ	連体詞	_	2	amod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=イロンナ,色んな,いろんな,いろんな,イロンナ,,,イロンナ,イロンナ,色んな
 2	メニュー	メニュー	NOUN	名詞-普通名詞-一般	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=メニュー,メニュー,メニュー,メニュー,メニュー,,,メニュー,メニュー,メニュー
@@ -13211,6 +13689,7 @@
 
 # newdoc id = test-s493
 # sent_id = test-s493
+# parallel_id = jagsd/test493
 # text = この手の本が翻訳されることは少ないと思っていたのだが,昨今のソーシャル流行りが要因かはわからないが,翻訳本が原書から1年もしないでリリースされたのはよい知らせだ。
 1	この	此の	DET	連体詞	_	2	det	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=連体詞|SpaceAfter=No|UnidicInfo=コノ,此の,この,この,コノ,,,コノ,コノ,此の
 2	手	手	NOUN	名詞-普通名詞-助数詞可能	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テ,手,手,手,テ,,,テ,テ,手
@@ -13268,6 +13747,7 @@
 
 # newdoc id = test-s494
 # sent_id = test-s494
+# parallel_id = jagsd/test494
 # text = 「1997〜1999」とは、FBIがデビューした年から本作が発売された年を意味する。
 1	「	「	PUNCT	補助記号-括弧開	_	4	punct	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-括弧開|SpaceAfter=No|UnidicInfo=,「,「,「,,,,,,「
 2	1997	1997	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=イチ,一九九七,1997,1997,イチキューキューナナ,,,イチキュウキュウナナ,イチキュウキュウナナ,1997
@@ -13298,6 +13778,7 @@
 
 # newdoc id = test-s495
 # sent_id = test-s495
+# parallel_id = jagsd/test495
 # text = 生きていくことは美しいことだといつも思う。
 1	生き	生きる	VERB	動詞-一般-上一段-カ行	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-上一段-カ行|SpaceAfter=No|UnidicInfo=イキル,生きる,生き,生きる,イキ,,,イキル,イキル,生きる
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助動詞-五段-カ行|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テイク,ていく
@@ -13315,6 +13796,7 @@
 
 # newdoc id = test-s496
 # sent_id = test-s496
+# parallel_id = jagsd/test496
 # text = ドラゴンズは9番チェンからの打順だったが、代打に水田を送る。
 1	ドラゴンズ	ドラゴン	NOUN	名詞-普通名詞-一般	_	17	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ドラゴン,ドラゴン,ドラゴンズ,ドラゴンズ,ドラゴンズ,,,ドラゴンズ,ドラゴンズ,ドラゴンズ
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -13337,6 +13819,7 @@
 
 # newdoc id = test-s497
 # sent_id = test-s497
+# parallel_id = jagsd/test497
 # text = ダウンタウンの17ブロックにわたって広がるシアター・ディストリクトには9つの著名な演技芸術団体が本部を置き、6ヶ所のホールが立地している。
 1	ダウンタウン	ダウンタウン	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダウンタウン,ダウンタウン,ダウンタウン,ダウンタウン,ダウンタウン,,,ダウンタウン,ダウンタウン,ダウンタウン
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13377,6 +13860,7 @@
 
 # newdoc id = test-s498
 # sent_id = test-s498
+# parallel_id = jagsd/test498
 # text = 昔ながらの「売りっぱなし」商売をしている。
 1	昔	昔	NOUN	名詞-普通名詞-副詞可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ムカシ,昔,昔,昔,ムカシ,,,ムカシ,ムカシナガラ,昔乍ら
 2	ながら	乍ら	NOUN	接尾辞-名詞的-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナガラ,乍ら,ながら,ながら,ナガラ,,,ナガラ,ムカシナガラ,昔乍ら
@@ -13394,6 +13878,7 @@
 
 # newdoc id = test-s499
 # sent_id = test-s499
+# parallel_id = jagsd/test499
 # text = 中学ではシェークスピア・ギリシア哲学・演劇にも熱中した。
 1	中学	中学	NOUN	名詞-普通名詞-一般	_	12	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チュウガク,中学,中学,中学,チューガク,,,チュウガク,チュウガク,中学
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -13413,6 +13898,7 @@
 
 # newdoc id = test-s500
 # sent_id = test-s500
+# parallel_id = jagsd/test500
 # text = 後の稲川組幹部)と知り合い、出口辰夫と兄弟分となった。
 1	後	後	NOUN	名詞-普通名詞-副詞可能	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ノチ,後,後,後,ノチ,,,ノチ,ノチ,後
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13435,6 +13921,7 @@
 
 # newdoc id = test-s501
 # sent_id = test-s501
+# parallel_id = jagsd/test501
 # text = 会議後は資料作成などに着手し、退社は夜12時前後。
 1	会議	会議	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カイギ,会議,会議,会議,カイギ,,,カイギ,カイギゴ,会議後
 2	後	後	NOUN	接尾辞-名詞的-副詞可能	_	8	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴ,後,後,後,ゴ,,,ゴ,カイギゴ,会議後
@@ -13456,6 +13943,7 @@
 
 # newdoc id = test-s502
 # sent_id = test-s502
+# parallel_id = jagsd/test502
 # text = 現在の計画停電の3時間であれば、つけっぱなしにしても大丈夫そうだ。
 1	現在	現在	NOUN	名詞-普通名詞-副詞可能	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゲンザイ,現在,現在,現在,ゲンザイ,,,ゲンザイ,ゲンザイ,現在
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13481,6 +13969,7 @@
 
 # newdoc id = test-s503
 # sent_id = test-s503
+# parallel_id = jagsd/test503
 # text = 皮肉なことに信濃町は,共産党タウン以上に北朝鮮的な街なのである。
 1	皮肉	皮肉	ADJ	名詞-普通名詞-形状詞可能	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=ヒニク,皮肉,皮肉,皮肉,ヒニク,,,ヒニク,ヒニク,皮肉
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -13506,6 +13995,7 @@
 
 # newdoc id = test-s504
 # sent_id = test-s504
+# parallel_id = jagsd/test504
 # text = 一般的に、貧栄養な外洋では生物過程による全エネルギー・炭素フラックスに占める微生物環の割合が沿岸や内湾よりも高い。
 1	一般	一般	NOUN	名詞-普通名詞-一般	_	33	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=イッパン,一般,一般,一般,イッパン,,,イッパン,イッパンテキ,一般的
 2	的	的	PART	接尾辞-形状詞的	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=テキ,的,的,的,テキ,,,テキ,イッパンテキ,一般的
@@ -13544,6 +14034,7 @@
 
 # newdoc id = test-s505
 # sent_id = test-s505
+# parallel_id = jagsd/test505
 # text = ストリンガー氏は震災発生時は米国におり、被災現場を訪れたのは初めて。
 1	ストリンガー	ストリンガー	PROPN	名詞-固有名詞-人名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ストリンガー,ストリンガー,ストリンガー,ストリンガー,ストリンガー,,,ストリンガー,ストリンガーシ,ストリンガー氏
 2	氏	氏	NOUN	接尾辞-名詞的-一般	_	19	nsubj:outer	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=シ,氏,氏,氏,シ,,,シ,ストリンガーシ,ストリンガー氏
@@ -13568,6 +14059,7 @@
 
 # newdoc id = test-s506
 # sent_id = test-s506
+# parallel_id = jagsd/test506
 # text = ジョージ・ハリスンの作品。
 1	ジョージ	ジョージ	PROPN	名詞-固有名詞-人名-一般	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=ジョージ,ジョージ,ジョージ,ジョージ,ジョージ,,,ジョージ,ジョージハリスン,ジョージ・ハリスン
 2	・	・	SYM	補助記号-一般	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-固有名詞-人名-一般|SpaceAfter=No|UnidicInfo=,・,・,・,,,,,ジョージハリスン,ジョージ・ハリスン
@@ -13578,6 +14070,7 @@
 
 # newdoc id = test-s507
 # sent_id = test-s507
+# parallel_id = jagsd/test507
 # text = 前作では10枚以上コインを取るとスーパーキノコが出てきたが、本作ではコインが5枚散らばるようになっている。
 1	前作	前作	NOUN	名詞-普通名詞-一般	_	14	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゼンサク,前作,前作,前作,ゼンサク,,,ゼンサク,ゼンサク,前作
 2	で	で	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=デ,で,で,で,デ,,,デ,デ,で
@@ -13615,6 +14108,7 @@
 
 # newdoc id = test-s508
 # sent_id = test-s508
+# parallel_id = jagsd/test508
 # text = 籾井王子から紀州街道旧道を西に1.5kmほど進み、海営宮池という池の近くの交差点を北に向かう脇道に入ったところに墓地があり、その北側に石碑と説明板がある。
 1	籾井	籾井	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=モロイ,モロイ,籾井,籾井,モロイ,,,モロイ,モロイオウジ,籾井王子
 2	王子	王子	PROPN	名詞-固有名詞-地名-一般	_	15	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=オウジ,オウジ,王子,王子,オージ,,,オウジ,モロイオウジ,籾井王子
@@ -13669,6 +14163,7 @@
 
 # newdoc id = test-s509
 # sent_id = test-s509
+# parallel_id = jagsd/test509
 # text = 2006年11月8日、関東地方から東北地方にかけてカリオペとリヌスによる恒星の掩蔽がアマチュア天文家たちによって観測され、カリオペとリヌスの正確な大きさと位置が求められた。
 1	2006	2006	NUM	名詞-数詞	_	6	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ六,2006,2006,ニゼロゼロロク,,,ニゼロゼロロク,ニゼロゼロロクネン,2006年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	6	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロロクネン,2006年
@@ -13723,6 +14218,7 @@
 
 # newdoc id = test-s510
 # sent_id = test-s510
+# parallel_id = jagsd/test510
 # text = 一方、東海地方北陸地方以東の東日本は、比較的広い沖積平野に恵まれていた上に、太平洋側を中心に低開発状態の洪積台地や河岸段丘面の農地開発の余地が大きく、日本海側を中心に扇状地でも開発の余地が広く存在したため、江戸時代に至っても、急峻な山地の傾斜面を切り開いて棚田をつくるまでに至らなかったところが多く、棚田はあまりつくられないか、つくられた場合でも畔や土手は傾斜が緩やかな土盛りとなり、西日本とは対照的な棚田風景となった。
 1	一方	一方	CCONJ	接続詞	_	134	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=イッポウ,一方,一方,一方,イッポー,,,イッポウ,イッポウ,一方
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -13863,6 +14359,7 @@
 
 # newdoc id = test-s511
 # sent_id = test-s511
+# parallel_id = jagsd/test511
 # text = 帰り道、あまり気持ちよかったのでフワフワしちゃいましたよ。
 1	帰り道	帰り道	NOUN	名詞-普通名詞-一般	_	9	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=カエリミチ,帰り道,帰り道,帰り道,カエリミチ,,,カエリミチ,カエリミチ,帰り道
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -13882,6 +14379,7 @@
 
 # newdoc id = test-s512
 # sent_id = test-s512
+# parallel_id = jagsd/test512
 # text = 当駅の所在する地名より。
 1	当駅	当駅	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウエキ,当駅,当駅,当駅,トーエキ,,,トウエキ,トウエキ,当駅
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -13893,6 +14391,7 @@
 
 # newdoc id = test-s513
 # sent_id = test-s513
+# parallel_id = jagsd/test513
 # text = 右腕からチャージショットを放つ「ハイパーZEROブラスター」は火力が高く、空中でのけん制にも使えるなどゼロにとって重要な技となる。
 1	右腕	右腕	NOUN	名詞-普通名詞-一般	_	6	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ミギウデ,右腕,右腕,右腕,ミギウデ,,,ミギウデ,ミギウデ,右腕
 2	から	から	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=カラ,から,から,から,カラ,,,カラ,カラ,から
@@ -13931,6 +14430,7 @@
 
 # newdoc id = test-s514
 # sent_id = test-s514
+# parallel_id = jagsd/test514
 # text = 本当に焼いただけでいただけるというところが気に入っています。
 1	本当	本当	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ホントウ,本当,本当,本当,ホントー,,,ホントウ,ホントウ,本当
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -13953,6 +14453,7 @@
 
 # newdoc id = test-s515
 # sent_id = test-s515
+# parallel_id = jagsd/test515
 # text = 安くて早いから、この系列店をよく使わせてもらっているが、ここはカットが下手過ぎる。
 1	安く	安い	ADJ	形容詞-一般-形容詞	_	3	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=ヤスイ,安い,安く,安い,ヤスク,,,ヤスイ,ヤスイ,安い
 2	て	て	SCONJ	助詞-接続助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-接続助詞|SpaceAfter=No|UnidicInfo=テ,て,て,て,テ,,,テ,テ,て
@@ -13982,6 +14483,7 @@
 
 # newdoc id = test-s516
 # sent_id = test-s516
+# parallel_id = jagsd/test516
 # text = また利用したいです。
 1	また	又	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	利用	利用	VERB	名詞-普通名詞-サ変可能	_	0	root	_	BunsetuBILabel=B|BunsetuPositionType=ROOT|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|SpaceAfter=No|UnidicInfo=リヨウ,利用,利用,利用,リヨー,,,リヨウ,リヨウスル,利用する
@@ -13992,6 +14494,7 @@
 
 # newdoc id = test-s517
 # sent_id = test-s517
+# parallel_id = jagsd/test517
 # text = 天理教は,新宿区高田馬場にある牛込大教会を開放。
 1	天理	天理	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=テンリ,テンリ,天理,天理,テンリ,,,テンリ,テンリキョウ,天理教
 2	教	教	NOUN	接尾辞-名詞的-一般	_	14	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウ,教,教,教,キョー,,,キョウ,テンリキョウ,天理教
@@ -14011,6 +14514,7 @@
 
 # newdoc id = test-s518
 # sent_id = test-s518
+# parallel_id = jagsd/test518
 # text = 馬鹿な事を続けていれば信者からの求心力がどんどん失われていくでしょうから,そのままカルト崩壊へGO!
 1	馬鹿	馬鹿	ADJ	名詞-普通名詞-形状詞可能	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=バカ,馬鹿,馬鹿,馬鹿,バカ,,,バカ,バカ,馬鹿
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -14044,6 +14548,7 @@
 
 # newdoc id = test-s519
 # sent_id = test-s519
+# parallel_id = jagsd/test519
 # text = 生理的に嫌。
 1	生理	生理	NOUN	名詞-普通名詞-一般	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=セイリ,生理,生理,生理,セーリ,,,セイリ,セイリテキ,生理的
 2	的	的	PART	接尾辞-形状詞的	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=I|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=テキ,的,的,的,テキ,,,テキ,セイリテキ,生理的
@@ -14053,6 +14558,7 @@
 
 # newdoc id = test-s520
 # sent_id = test-s520
+# parallel_id = jagsd/test520
 # text = 言い回しや態度が妙に芝居がかっており、プレイヤーからは「キモイ」と言われていた。
 1	言い回し	言い回し	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=イイマワシ,言い回し,言い回し,言い回し,イーマワシ,,,イイマワシ,イイマワシ,言い回し
 2	や	や	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ヤ,や,や,や,ヤ,,,ヤ,ヤ,や
@@ -14081,6 +14587,7 @@
 
 # newdoc id = test-s521
 # sent_id = test-s521
+# parallel_id = jagsd/test521
 # text = 十メートル長の巨大なライフルと、周囲の景色に同化する機能を持つマントを駆使するスナイパー。
 1	十	十	NUM	名詞-数詞	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジュウ,十,十,十,ジュー,,,ジュウ,ジュウメートルチョウ,十メートル長
 2	メートル	メートル	NOUN	名詞-普通名詞-助数詞可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=メートル,メートル,メートル,メートル,メートル,,,メートル,ジュウメートルチョウ,十メートル長
@@ -14109,6 +14616,7 @@
 
 # newdoc id = test-s522
 # sent_id = test-s522
+# parallel_id = jagsd/test522
 # text = 猫が亡くなった今でも心から感謝しています。
 1	猫	猫	NOUN	名詞-普通名詞-一般	_	3	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ネコ,猫,猫,猫,ネコ,,,ネコ,ネコ,猫
 2	が	が	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ガ,が,が,が,ガ,,,ガ,ガ,が
@@ -14128,6 +14636,7 @@
 
 # newdoc id = test-s523
 # sent_id = test-s523
+# parallel_id = jagsd/test523
 # text = 2008年1月から6月に振り込め詐欺・オレオレ詐欺で使用された携帯電話約2,300台のうち約7割がソフトバンク携帯だったとの報道が12月にあった。
 1	2008	2008	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ八,2008,2008,ニゼロゼロハチ,,,ニゼロゼロハチ,ニゼロゼロハチネン,2008年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロハチネン,2008年
@@ -14178,6 +14687,7 @@
 
 # newdoc id = test-s524
 # sent_id = test-s524
+# parallel_id = jagsd/test524
 # text = これにより業務協力で会員社の経営の効率化を図った。
 1	これ	此れ	PRON	代名詞	_	15	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=代名詞|SpaceAfter=No|UnidicInfo=コレ,此れ,これ,これ,コレ,,,コレ,コレ,此れ
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=FUNC|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニヨリ,により
@@ -14199,6 +14709,7 @@
 
 # newdoc id = test-s525
 # sent_id = test-s525
+# parallel_id = jagsd/test525
 # text = 水牛のような角を持つ漆黒の巨人の姿をしており、目から放つ光線であらゆる物を砂に変えて崩壊させる。
 1	水牛	水牛	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=スイギュウ,水牛,水牛,水牛,スイギュー,,,スイギュウ,スイギュウ,水牛
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -14236,6 +14747,7 @@
 
 # newdoc id = test-s526
 # sent_id = test-s526
+# parallel_id = jagsd/test526
 # text = ただし、書いていないのか未採択なのかの区別をつけるために「研究」節内で「*私立大学学術研究高度化推進事業の採択はない。
 1	ただし	但し	CCONJ	接続詞	_	38	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=タダシ,但し,ただし,ただし,タダシ,,,タダシ,タダシ,但し
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、
@@ -14279,6 +14791,7 @@
 
 # newdoc id = test-s527
 # sent_id = test-s527
+# parallel_id = jagsd/test527
 # text = 男は女の為に闘い抜いたとき女は心を寄せるのであって,何もしないで足の長さで女を釣ろうとするのはルンペンのやることである。
 1	男	男	NOUN	名詞-普通名詞-一般	_	7	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=オトコ,男,男,男,オトコ,,,オトコ,オトコ,男
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -14327,6 +14840,7 @@
 
 # newdoc id = test-s528
 # sent_id = test-s528
+# parallel_id = jagsd/test528
 # text = 後続の車両の方がBAの番号は若いが、BA-27の27は開発年度から来ているものと以降の車両はほぼ製作順に番号が並んでいる。
 1	後続	後続	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コウゾク,後続,後続,後続,コーゾク,,,コウゾク,コウゾク,後続
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -14374,6 +14888,7 @@
 
 # newdoc id = test-s529
 # sent_id = test-s529
+# parallel_id = jagsd/test529
 # text = ご理解とご協力,よろしくお願いいたします。
 1	ご	御	NOUN	接頭辞	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴ,御,ご,ご,ゴ,,,ゴ,ゴリカイ,御理解
 2	理解	理解	NOUN	名詞-普通名詞-サ変可能	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=リカイ,理解,理解,理解,リカイ,,,リカイ,ゴリカイ,御理解
@@ -14390,6 +14905,7 @@
 
 # newdoc id = test-s530
 # sent_id = test-s530
+# parallel_id = jagsd/test530
 # text = 亜大の東浜も6回で12三振を奪った。
 1	亜大	亜大	PROPN	名詞-固有名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=アダイ,亜大,亜大,亜大,アダイ,,,アダイ,アダイ,亜大
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -14407,6 +14923,7 @@
 
 # newdoc id = test-s531
 # sent_id = test-s531
+# parallel_id = jagsd/test531
 # text = 直人の妻。
 1	直人	直人	PROPN	名詞-固有名詞-人名-名	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-名|SpaceAfter=No|UnidicInfo=ナオト,ナオト,直人,直人,ナオト,,,ナオト,ナオト,直人
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -14415,6 +14932,7 @@
 
 # newdoc id = test-s532
 # sent_id = test-s532
+# parallel_id = jagsd/test532
 # text = まあAIDMA,AISASをはじめとするSIPSみたいな言葉には最近嫌悪感すらするのだけど,モデルとしては判りやすい。
 1	まあ	まあ	ADV	副詞	_	29	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=マア,まあ,まあ,まあ,マー,,,マア,マア,まあ
 2	AIDMA	AIDMA	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アイドマ,ＡＩＤＭＡ,AIDMA,AIDMA,アイドマ,,,アイドマ,アイドマ,AIDMA
@@ -14450,6 +14968,7 @@
 
 # newdoc id = test-s533
 # sent_id = test-s533
+# parallel_id = jagsd/test533
 # text = 2006年には柏レイソルの監督に就任。
 1	2006	2006	NUM	名詞-数詞	_	2	nummod	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ニ,二ゼロゼロ六,2006,2006,ニゼロゼロロク,,,ニゼロゼロロク,ニゼロゼロロクネン,2006年
 2	年	年	NOUN	名詞-普通名詞-助数詞可能	_	10	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-数詞|SpaceAfter=No|UnidicInfo=ネン,年,年,年,ネン,,,ネン,ニゼロゼロロクネン,2006年
@@ -14465,6 +14984,7 @@
 
 # newdoc id = test-s534
 # sent_id = test-s534
+# parallel_id = jagsd/test534
 # text = ポッドキャスト用アグリゲータの主な目的はRSSに関連付けされているポッドキャスト・ファイルのダウンロードだが、音楽再生機能を持ち、ダウンロードしたファイルを直接再生できるものも多い。
 1	ポッド	ポッド	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ポッド,ポッド,ポッド,ポッド,ポッド,,,ポッド,ポッドキャストヨウ,ポッドキャスト用
 2	キャスト	キャスト	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キャスト,キャスト,キャスト,キャスト,キャスト,,,キャスト,ポッドキャストヨウ,ポッドキャスト用
@@ -14512,6 +15032,7 @@
 
 # newdoc id = test-s535
 # sent_id = test-s535
+# parallel_id = jagsd/test535
 # text = 味付けは、あっさり目で、かなり調味料に気を使っているのかもしれません。
 1	味付け	味付け	NOUN	名詞-普通名詞-サ変可能	_	4	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=アジツケ,味付け,味付け,味付け,アジツケ,,,アジツケ,アジツケ,味付け
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -14539,6 +15060,7 @@
 
 # newdoc id = test-s536
 # sent_id = test-s536
+# parallel_id = jagsd/test536
 # text = ブラジルだけが、モーターやエンジンなど各国の先端技術を組み合わせることで、数千メートルの環境変化に耐えられる独自技術を開発した。
 1	ブラジル	ブラジル	PROPN	名詞-固有名詞-地名-国	_	29	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-国|SpaceAfter=No|UnidicInfo=ブラジル,ブラジル,ブラジル,ブラジル,ブラジル,,,ブラジル,ブラジル,ブラジル
 2	だけ	だけ	ADP	助詞-副助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ダケ,だけ,だけ,だけ,ダケ,,,ダケ,ダケ,だけ
@@ -14575,6 +15097,7 @@
 
 # newdoc id = test-s537
 # sent_id = test-s537
+# parallel_id = jagsd/test537
 # text = こうした理由で,例えプラセボとしても,医療関係者がホメオパシーを治療に使用することは認められません。
 1	こう	こう	ADV	副詞	_	2	advmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=副詞|SpaceAfter=No|UnidicInfo=コウ,こう,こう,こう,コー,,,コウ,コウ,こう
 2	し	為る	VERB	動詞-非自立可能-サ行変格	_	4	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-サ行変格|PrevUDLemma=する|SpaceAfter=No|UnidicInfo=スル,為る,し,する,シ,,,スル,スル,する
@@ -14609,6 +15132,7 @@
 
 # newdoc id = test-s538
 # sent_id = test-s538
+# parallel_id = jagsd/test538
 # text = 新聞は,助産師が所属する団体名や療法名を報じていませんが,ホメオパシーを用いる団体と思われます。
 1	新聞	新聞	NOUN	名詞-普通名詞-一般	_	15	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シンブン,新聞,新聞,新聞,シンブン,,,シンブン,シンブン,新聞
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -14643,6 +15167,7 @@
 
 # newdoc id = test-s539
 # sent_id = test-s539
+# parallel_id = jagsd/test539
 # text = 支持者によって20世紀最大の神学者と称される新正統主義のカール・バルトは、未完の主著「教会教義学」全4巻における第3巻、邦訳全36分冊中11冊分を創造説に割いている。
 1	支持	支持	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シジ,支持,支持,支持,シジ,,,シジ,シジシャ,支持者
 2	者	者	NOUN	接尾辞-名詞的-一般	_	13	obl	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シャ,者,者,者,シャ,,,シャ,シジシャ,支持者
@@ -14704,6 +15229,7 @@
 
 # newdoc id = test-s540
 # sent_id = test-s540
+# parallel_id = jagsd/test540
 # text = 日産は8月6日、軽自動車「オッティ」の一部仕様を変更し、同日より発売した。
 1	日産	日産	PROPN	名詞-固有名詞-一般	_	23	nsubj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-固有名詞-一般|SpaceAfter=No|UnidicInfo=ニッサン,日産,日産,日産,ニッサン,,,ニッサン,ニッサン,日産
 2	は	は	ADP	助詞-係助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-係助詞|SpaceAfter=No|UnidicInfo=ハ,は,は,は,ワ,,,ハ,ハ,は
@@ -14734,6 +15260,7 @@
 
 # newdoc id = test-s541
 # sent_id = test-s541
+# parallel_id = jagsd/test541
 # text = 翼端に付けていた増槽は機体の重心が前に寄り過ぎるために使用されず、主翼中央下面に滑らかな形状で装着できるように再設計された。
 1	翼端	翼端	NOUN	名詞-普通名詞-一般	_	3	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヨクタン,翼端,翼端,翼端,ヨクタン,,,ヨクタン,ヨクタン,翼端
 2	に	に	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ニ,に,に,に,ニ,,,ニ,ニ,に
@@ -14779,6 +15306,7 @@
 
 # newdoc id = test-s542
 # sent_id = test-s542
+# parallel_id = jagsd/test542
 # text = 若い頃は土司の小作人や軍の人夫をして過ごす。
 1	若い	若い	ADJ	形容詞-一般-形容詞	_	2	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形容詞-一般-形容詞|SpaceAfter=No|UnidicInfo=ワカイ,若い,若い,若い,ワカイ,,,ワカイ,ワカイ,若い
 2	頃	頃	NOUN	名詞-普通名詞-副詞可能	_	15	obl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=コロ,頃,頃,頃,コロ,,,コロ,コロ,頃
@@ -14799,6 +15327,7 @@
 
 # newdoc id = test-s543
 # sent_id = test-s543
+# parallel_id = jagsd/test543
 # text = クールな性格で、自らを「いやな子」と称する。
 1	クール	クール	ADJ	形状詞-一般	_	3	acl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=形状詞-一般|SpaceAfter=No|UnidicInfo=クール,クール,クール,クール,クール,,,クール,クール,クール
 2	な	だ	AUX	助動詞-助動詞-ダ	_	1	aux	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助動詞-助動詞-ダ|SpaceAfter=No|UnidicInfo=ダ,だ,な,だ,ナ,,,ダ,ダ,だ
@@ -14818,6 +15347,7 @@
 
 # newdoc id = test-s544
 # sent_id = test-s544
+# parallel_id = jagsd/test544
 # text = ヴァランゲル半島の北東部に位置する。
 1	ヴァランゲル	ヴァランゲル	PROPN	名詞-固有名詞-地名-一般	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=バランゲル,バランゲル,ヴァランゲル,ヴァランゲル,バランゲル,,,バランゲル,バランゲルハントウ,ヴァランゲル半島
 2	半島	半島	NOUN	名詞-普通名詞-一般	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-固有名詞-地名-一般|SpaceAfter=No|UnidicInfo=ハントウ,半島,半島,半島,ハントー,,,ハントウ,バランゲルハントウ,ヴァランゲル半島
@@ -14831,6 +15361,7 @@
 
 # newdoc id = test-s545
 # sent_id = test-s545
+# parallel_id = jagsd/test545
 # text = 統一教会足立教会の週報でも今回のイベントが信者に対して告知されていることから,集会の参加者にも統一教会信者が動員されるものと思われます。
 1	統一	統一	NOUN	名詞-普通名詞-サ変可能	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=トウイツ,統一,統一,統一,トーイツ,,,トウイツ,トウイツキョウカイアダチキョウカイ,統一教会足立教会
 2	教会	教会	NOUN	名詞-普通名詞-一般	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=キョウカイ,教会,教会,教会,キョーカイ,,,キョウカイ,トウイツキョウカイアダチキョウカイ,統一教会足立教会
@@ -14878,6 +15409,7 @@
 
 # newdoc id = test-s546
 # sent_id = test-s546
+# parallel_id = jagsd/test546
 # text = 第7回以降の大会で、サッカーのビクトリーゴールのように条件を満たした時点で勝ちとなる特別な勝利条件が加えられることが度々あった。
 1	第	第	NOUN	接頭辞	_	4	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ダイ,第,第,第,ダイ,,,ダイ,ダイナナカイイコウ,第7回以降
 2	7	7	NUM	名詞-数詞	_	4	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ナナ,七,7,7,ナナ,,,ナナ,ダイナナカイイコウ,第7回以降
@@ -14919,6 +15451,7 @@
 
 # newdoc id = test-s547
 # sent_id = test-s547
+# parallel_id = jagsd/test547
 # text = 反乱軍の一人。
 1	反乱	反乱	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ハンラン,反乱,反乱,反乱,ハンラン,,,ハンラン,ハンラングン,反乱軍
 2	軍	軍	NOUN	名詞-普通名詞-一般	_	4	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=グン,軍,軍,軍,グン,,,グン,ハンラングン,反乱軍
@@ -14928,6 +15461,7 @@
 
 # newdoc id = test-s548
 # sent_id = test-s548
+# parallel_id = jagsd/test548
 # text = 建築評論家。
 1	建築	建築	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケンチク,建築,建築,建築,ケンチク,,,ケンチク,ケンチクヒョウロンカ,建築評論家
 2	評論	評論	NOUN	名詞-普通名詞-サ変可能	_	3	compound	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ヒョウロン,評論,評論,評論,ヒョーロン,,,ヒョウロン,ケンチクヒョウロンカ,建築評論家
@@ -14936,6 +15470,7 @@
 
 # newdoc id = test-s549
 # sent_id = test-s549
+# parallel_id = jagsd/test549
 # text = しかし中松氏については警察関係者も苦笑い。
 1	しかし	然し	CCONJ	接続詞	_	12	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=シカシ,然し,しかし,しかし,シカシ,,,シカシ,シカシ,然し
 2	中松	中松	PROPN	名詞-固有名詞-人名-姓	_	3	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-固有名詞-人名-姓|SpaceAfter=No|UnidicInfo=ナカマツ,ナカマツ,中松,中松,ナカマツ,,,ナカマツ,ナカマツシ,中松氏
@@ -14953,6 +15488,7 @@
 
 # newdoc id = test-s550
 # sent_id = test-s550
+# parallel_id = jagsd/test550
 # text = 終盤のツール・ド・おきなわでは鳩村と共に最後まで走りぬき、30位に入る健闘を見せる。
 1	終盤	終盤	NOUN	名詞-普通名詞-一般	_	7	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=シュウバン,終盤,終盤,終盤,シューバン,,,シュウバン,シュウバン,終盤
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -14983,6 +15519,7 @@
 
 # newdoc id = test-s551
 # sent_id = test-s551
+# parallel_id = jagsd/test551
 # text = 護符の由来どころか,そもそも杉山先生の気功能力の出自もナゾです。
 1	護符	護符	NOUN	名詞-普通名詞-一般	_	3	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ゴフ,護符,護符,護符,ゴフ,,,ゴフ,ゴフ,護符
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -15005,6 +15542,7 @@
 
 # newdoc id = test-s552
 # sent_id = test-s552
+# parallel_id = jagsd/test552
 # text = 見学がてらの面接後も、電話で見学してみた印象を確認してくださって後で比較検討しやすいようにとアドバイスしてくださいました。
 1	見学	見学	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ケンガク,見学,見学,見学,ケンガク,,,ケンガク,ケンガクガテラ,見学がてら
 2	がてら	がてら	NOUN	接尾辞-名詞的-副詞可能	_	5	nmod	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ガテラ,がてら,がてら,がてら,ガテラ,,,ガテラ,ケンガクガテラ,見学がてら
@@ -15046,6 +15584,7 @@
 
 # newdoc id = test-s553
 # sent_id = test-s553
+# parallel_id = jagsd/test553
 # text = プラスミドを改変してベクターとして利用する。
 1	プラスミド	プラスミド	NOUN	名詞-普通名詞-一般	_	3	obj	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=プラスミド,プラスミド,プラスミド,プラスミド,プラスミド,,,プラスミド,プラスミド,プラスミド
 2	を	を	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ヲ,を,を,を,オ,,,ヲ,ヲ,を
@@ -15062,6 +15601,7 @@
 
 # newdoc id = test-s554
 # sent_id = test-s554
+# parallel_id = jagsd/test554
 # text = 駐車場は狭いので混みあう時間帯は注意ですが、事前に電話をして到着時間を伝えておけば良いですね。
 1	駐車	駐車	NOUN	名詞-普通名詞-サ変可能	_	2	compound	_	BunsetuBILabel=B|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=チュウシャ,駐車,駐車,駐車,チューシャ,,,チュウシャ,チュウシャジョウ,駐車場
 2	場	場	NOUN	接尾辞-名詞的-一般	_	4	nsubj	_	BunsetuBILabel=I|BunsetuPositionType=SEM_HEAD|LUWBILabel=I|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=ジョウ,場,場,場,ジョー,,,ジョウ,チュウシャジョウ,駐車場
@@ -15097,6 +15637,7 @@
 
 # newdoc id = test-s555
 # sent_id = test-s555
+# parallel_id = jagsd/test555
 # text = 散髪のやり方次第で頭脳は発達すると考えて、どの店の散髪がよいか理髪店を絶えず替えていた。
 1	散髪	散髪	NOUN	名詞-普通名詞-サ変可能	_	5	nmod	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=名詞-普通名詞-一般|SpaceAfter=No|UnidicInfo=サンパツ,散髪,散髪,散髪,サンパツ,,,サンパツ,サンパツ,散髪
 2	の	の	ADP	助詞-格助詞	_	1	case	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-格助詞|SpaceAfter=No|UnidicInfo=ノ,の,の,の,ノ,,,ノ,ノ,の
@@ -15132,6 +15673,7 @@
 
 # newdoc id = test-s556
 # sent_id = test-s556
+# parallel_id = jagsd/test556
 # text = 見上げる程の大きさの弧形が地表に露出しているが、これですら全体の一部でしかなく、全体は地殻を貫通して星の核にまで達している。
 1	見上げる	見上げる	VERB	動詞-一般-下一段-ガ行	_	4	advcl	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=動詞-一般-下一段-ガ行|SpaceAfter=No|UnidicInfo=ミアゲル,見上げる,見上げる,見上げる,ミアゲル,,,ミアゲル,ミアゲル,見上げる
 2	程	ほど	PART	助詞-副助詞	_	1	mark	_	BunsetuBILabel=I|BunsetuPositionType=SYN_HEAD|LUWBILabel=B|LUWPOS=助詞-副助詞|SpaceAfter=No|UnidicInfo=ホド,ほど,程,程,ホド,,,ホド,ホド,ほど
@@ -15178,6 +15720,7 @@
 
 # newdoc id = test-s557
 # sent_id = test-s557
+# parallel_id = jagsd/test557
 # text = また、顕彰当時現役の選手も存在したが、いずれも既に全女を退団していた。
 1	また	又	CCONJ	接続詞	_	19	cc	_	BunsetuBILabel=B|BunsetuPositionType=SEM_HEAD|LUWBILabel=B|LUWPOS=接続詞|SpaceAfter=No|UnidicInfo=マタ,又,また,また,マタ,,,マタ,マタ,又
 2	、	、	PUNCT	補助記号-読点	_	1	punct	_	BunsetuBILabel=I|BunsetuPositionType=CONT|LUWBILabel=B|LUWPOS=補助記号-読点|SpaceAfter=No|UnidicInfo=,、,、,、,,,,,,、


### PR DESCRIPTION
- update README metadata and add parallel IDs
     - add "Parallel: "jagsd" to indicate parallel data availability
- add " parallel_id = jagsd/{dev{n}, test{n}, train{n}}/part{n} alt{n}" format to support automated parallel sentences identification, where n = any number (positive intergers, arabic numerals, starts with 1)